### PR TITLE
Legg til logikk for ferdigstilling av vedtak v2

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakService.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakService.java
@@ -190,7 +190,13 @@ public class VedtakService {
             metricsService.rapporterFeilendeFerdigstillingAvJournalpost();
         }
 
-        vedtaksstotteRepository.ferdigstillVedtakV2(vedtakId);
+        transactor.executeWithoutResult(status -> {
+            vedtaksstotteRepository.settGjeldendeVedtakTilHistorisk(vedtak.getAktorId());
+            vedtaksstotteRepository.ferdigstillVedtakV2(vedtakId);
+            beslutteroversiktRepository.slettBruker(vedtak.getId());
+        });
+
+        vedtakStatusEndringService.vedtakSendt(vedtak, authKontekst.getFnr());
 
         String bestillingsId = null;
         try {

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
@@ -143,6 +143,7 @@ public class VedtakServiceTest {
         reset(meldingRepository);
         reset(unleashService);
         reset(dokdistribusjonClient);
+        reset(vedtakStatusEndringService);
         doReturn(TEST_VEILEDER_IDENT).when(authService).getInnloggetVeilederIdent();
         when(veilederService.hentEnhetNavn(TEST_OPPFOLGINGSENHET_ID)).thenReturn(TEST_OPPFOLGINGSENHET_NAVN);
         when(veilederService.hentVeileder(TEST_VEILEDER_IDENT)).thenReturn(new Veileder().setIdent(TEST_VEILEDER_IDENT).setNavn(TEST_VEILEDER_NAVN));
@@ -559,8 +560,10 @@ public class VedtakServiceTest {
         withContext(() -> {
             gittTilgang();
             Vedtak sendtVedtak = hentVedtak();
+            assertTrue(sendtVedtak.isGjeldende());
             assertEquals(TEST_DOKUMENT_BESTILLING_ID, sendtVedtak.getDokumentbestillingId());
         });
+        verify(vedtakStatusEndringService).vedtakSendt(any(), any());
     }
 
     private void assertSendtVedtak() {


### PR DESCRIPTION
Tilsvarende logikk som for versjon 1: sett evt tidligere gjeldende vedtak til historisk, slett bruker fra beslutteroversikt, og send status endring.