### PR TITLE
Legg til sender-lås for fatt vedtak v2

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakService.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakService.java
@@ -113,7 +113,13 @@ public class VedtakService {
         if (brukNyDokIntegrasjon()) {
             log.info(format("Sender og ferdigstiller vedtak med nye integrasjoner (vedtak id = %s, aktør id = %s)",
                     vedtak.getId(), authKontekst.getAktorId()));
-            return sendDokumentOgFerdigstillV2(vedtak, authKontekst);
+            // Oppdaterer vedtak til "sender" tilstand for å redusere risiko for dupliserte utsendelser av dokument.
+            vedtaksstotteRepository.oppdaterSender(vedtak.getId(), true);
+            try {
+                return sendDokumentOgFerdigstillV2(vedtak, authKontekst);
+            } finally {
+                vedtaksstotteRepository.oppdaterSender(vedtak.getId(), false);
+            }
         } else {
             log.info(format("Sender og ferdigstiller vedtak med gammel integrasjon (vedtak id = %s, aktør id = %s)",
                     vedtak.getId(), authKontekst.getAktorId()));


### PR DESCRIPTION
Legg til sender-lås funksjonalitet for fatt vedtak v2 for å redusere risiko for å sende duplikate dokument. Skrive om test av funksjonalitet i forsøk på å gjøre testen mer stabil.