### PR TITLE
Forenkler logikk for innsatsbehov

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/controller/InnsatsbehovController.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/controller/InnsatsbehovController.kt
@@ -16,7 +16,7 @@ class InnsatsbehovController(val innsatsbehovService: InnsatsbehovService) {
 
     @GetMapping
     fun hentInnsatsbehov(@RequestParam("fnr") fnr: Fnr): ResponseEntity<InnsatsbehovDTO> {
-        return innsatsbehovService.gjeldendeInnsatsbehov(fnr)
+        return innsatsbehovService.sisteInnsatsbehov(fnr)
             ?.let { ResponseEntity(InnsatsbehovDTO.fraInnsatsbehov(it), HttpStatus.OK) }
             ?: ResponseEntity(HttpStatus.NO_CONTENT)
     }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepository.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepository.java
@@ -110,6 +110,11 @@ public class VedtaksstotteRepository {
         return queryForObjectOrNull(() -> db.queryForObject(sql, VedtaksstotteRepository::mapVedtak, aktorId));
     }
 
+    public Vedtak hentSisteVedtak(String aktorId) {
+        String sql = format("SELECT * FROM %s WHERE %s = ? AND %s = ? ORDER BY %s DESC LIMIT 1", VEDTAK_TABLE, AKTOR_ID, STATUS, VEDTAK_FATTET);
+        return queryForObjectOrNull(() -> db.queryForObject(sql, VedtaksstotteRepository::mapVedtak, aktorId, VedtakStatus.SENDT.name()));
+    }
+
     public void settGjeldendeVedtakTilHistorisk(String aktorId) {
        db.update("UPDATE VEDTAK SET GJELDENDE = false WHERE AKTOR_ID = ? AND GJELDENDE = true", aktorId);
     }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/utils/OppfolgingUtils.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/utils/OppfolgingUtils.java
@@ -40,17 +40,4 @@ public class OppfolgingUtils {
             return 0;
         });
     }
-
-    public static boolean erDatoInnenforOppfolgingsperiode(ZonedDateTime dato,
-                                                           OppfolgingPeriodeDTO oppfolgingPeriode) {
-        return !dato.isBefore(oppfolgingPeriode.getStartDato()) &&
-                (oppfolgingPeriode.getSluttDato() == null || !dato.isAfter(oppfolgingPeriode.getSluttDato()));
-
-    }
-
-    public static boolean erOppfolgingsperiodeAktiv(OppfolgingPeriodeDTO oppfolgingPeriode) {
-        ZonedDateTime now = ZonedDateTime.now();
-        return !oppfolgingPeriode.getStartDato().isAfter(now) &&
-                (oppfolgingPeriode.getSluttDato() == null || !oppfolgingPeriode.getSluttDato().isBefore(now));
-    }
 }

--- a/src/test/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepositoryTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepositoryTest.java
@@ -18,6 +18,8 @@ import java.time.LocalDateTime;
 
 import static no.nav.veilarbvedtaksstotte.domain.vedtak.BeslutterProsessStatus.GODKJENT_AV_BESLUTTER;
 import static no.nav.veilarbvedtaksstotte.domain.vedtak.BeslutterProsessStatus.KLAR_TIL_BESLUTTER;
+import static no.nav.veilarbvedtaksstotte.domain.vedtak.VedtakStatus.SENDT;
+import static no.nav.veilarbvedtaksstotte.domain.vedtak.VedtakStatus.UTKAST;
 import static no.nav.veilarbvedtaksstotte.utils.TestData.*;
 import static org.junit.Assert.*;
 
@@ -195,5 +197,22 @@ public class VedtaksstotteRepositoryTest {
 
         assertNotNull(fattetVedtak);
         assertNotNull("Vedtak Fattet tidspunkt kan ikke vare null", fattetVedtak.getVedtakFattet());
+    }
+
+    @Test
+    public void henterSisteVedtak() {
+        String sql =
+                "INSERT INTO VEDTAK(AKTOR_ID, VEILEDER_IDENT, OPPFOLGINGSENHET_ID, STATUS, UTKAST_SIST_OPPDATERT, VEDTAK_FATTET)"
+                        + " values(?, ?, ?, ?, ?, ?)";
+        LocalDateTime now = LocalDateTime.now();
+        db.update(sql, TEST_AKTOR_ID, "veileder1", TEST_OPPFOLGINGSENHET_ID, SENDT.name(), now.minusDays(2), now.minusDays(2));
+        db.update(sql, TEST_AKTOR_ID, "veileder2", TEST_OPPFOLGINGSENHET_ID, SENDT.name(), now.minusDays(1), now.minusDays(1));
+        db.update(sql, TEST_AKTOR_ID, "veileder3", TEST_OPPFOLGINGSENHET_ID, SENDT.name(), now.minusDays(3), now.minusDays(3));
+        db.update(sql, TEST_AKTOR_ID, "veileder4", TEST_OPPFOLGINGSENHET_ID, UTKAST.name(), now, now);
+
+        Vedtak vedtak = vedtaksstotteRepository.hentSisteVedtak(TEST_AKTOR_ID);
+
+        assertNotNull(vedtak);
+        assertEquals("veileder2", vedtak.getVeilederIdent());
     }
 }

--- a/src/test/java/no/nav/veilarbvedtaksstotte/utils/OppfolgingUtilsTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/utils/OppfolgingUtilsTest.java
@@ -37,43 +37,6 @@ public class OppfolgingUtilsTest {
         assertEquals(periode2, maybePeriode.get());
     }
 
-
-    @Test
-    public void erDatoInnenforOppfolgingsperiode__riktig_svar_for_om_dato_er_innenfor_periode() {
-        ZonedDateTime now = now();
-
-        assertTrue("innenfor periode",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now, periode(now.minusDays(1), now)));
-
-        assertTrue("innenfor når dato er lik startdato",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now, periode(now, now.plusDays(1))));
-        assertTrue("innenfor når dato er lik sluttdato",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now, periode(now.minusDays(1), now)));
-
-        assertFalse("utenfor når dato er før startdato",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now.minusDays(1).minusSeconds(1), periode(now.minusDays(1), now)));
-        assertFalse("utenfor når dato er etter sluttdato",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now.plusDays(1).plusSeconds(1), periode(now, now.plusDays(1))));
-
-        assertTrue("innenfor når dato er etter startdato og sluttdato er null",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now, periode(now.minusDays(1), null)));
-        assertFalse("utenfor når dato er før startdato og sluttdato er null",
-                OppfolgingUtils.erDatoInnenforOppfolgingsperiode(now.minusDays(1).minusSeconds(1), periode(now.minusDays(1), null)));
-    }
-
-    @Test
-    public void erOppfolgingsperiodeAktiv__periode_er_aktiv_dersom_dagens_dato_er_innenfor() {
-        assertTrue("aktiv dersom startdato er før nå og sluttdato er null",
-                OppfolgingUtils.erOppfolgingsperiodeAktiv(periode(now().minusSeconds(10), null)));
-        assertTrue("aktiv dersom startdato er før nå og sluttdato er etter nå",
-                OppfolgingUtils.erOppfolgingsperiodeAktiv(periode(now().minusSeconds(10), now().plusSeconds(10))));
-
-        assertFalse("ikke aktiv dersom startdato er etter nå",
-                OppfolgingUtils.erOppfolgingsperiodeAktiv(periode(now().plusSeconds(10), null)));
-        assertFalse("ikke aktiv dersom sluttdato er før nå",
-                OppfolgingUtils.erOppfolgingsperiodeAktiv(periode(now().minusSeconds(20), now().minusSeconds(10))));
-    }
-
     private OppfolgingPeriodeDTO periode(ZonedDateTime start, ZonedDateTime slutt) {
         OppfolgingPeriodeDTO periode = new OppfolgingPeriodeDTO();
         periode.setStartDato(start);


### PR DESCRIPTION
Tar bort logikk for gjeldende innsatsbehov basert på oppfølgingsperiode. Logikk endret til å returnere innsatsbehov fra siste vedtak enten fra ny løsning eller Arena.