### PR TITLE
Forenkler sjekk for om innsatsbehov fra Arena skal publiseres på Kafka

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/InnsatsbehovService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/InnsatsbehovService.kt
@@ -112,7 +112,7 @@ class InnsatsbehovService(
 
         // hindrer at vi republiserer innsatsbehov dersom eldre meldinger skulle bli konsumert:
         val sisteFraArena = finnSisteArenaVedtak(arenaVedtakListe)
-        val erSisteFraArena = fraArena && sisteFraArena == arenaVedtak
+        val erSisteFraArena = fraArena && sisteFraArena?.hendelseId == arenaVedtak.hendelseId
 
         if (erSisteFraArena) {
             kafkaProducerService.sendInnsatsbehov(innsatsbehov)

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/InnsatsbehovServiceTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/InnsatsbehovServiceTest.kt
@@ -31,6 +31,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.*
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.random.Random.Default.nextLong
 
 class InnsatsbehovServiceTest : DatabaseTest() {
 
@@ -572,7 +573,7 @@ class InnsatsbehovServiceTest : DatabaseTest() {
         innsatsgruppe: ArenaInnsatsgruppe = ArenaInnsatsgruppe.BFORM,
         hovedmal: ArenaHovedmal = ArenaHovedmal.SKAFFEA,
         operationTimestamp: LocalDateTime = LocalDateTime.now(),
-        hendelseId: Long = 12345
+        hendelseId: Long = nextLong()
     ): ArenaVedtak {
         val arenaVedtak = ArenaVedtak(
             fnr = fnr,


### PR DESCRIPTION
Sammenligner om Kafka-melding fra Arena er den siste basert på hendelseId i stede for equality-sjekk på hele ArenaVedtak-objektet.