### PR TITLE
Produser innsatsbehov på Kafka on prem og Aiven

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -55,5 +55,7 @@ spec:
       value: aapen-oppfolging-vedtakStatusEndring-v1-q1
     - name: ARENA_VEDTAK_TOPIC
       value: aapen-arena-14aVedtakIverksatt-v1-q1
+    - name: INNSATSBEHOV_TOPIC
+      value: aapen-oppfolging-innsatsbehov-v1-dev
   envFrom:
     - configmap: pto-config

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -53,5 +53,7 @@ spec:
       value: aapen-oppfolging-vedtakStatusEndring-v1-p
     - name: ARENA_VEDTAK_TOPIC
       value: aapen-arena-14aVedtakIverksatt-v1-p
+    - name: INNSATSBEHOV_TOPIC
+      value: aapen-oppfolging-innsatsbehov-v1-prod
   envFrom:
     - configmap: pto-config

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/KafkaConfig.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/KafkaConfig.java
@@ -89,7 +89,8 @@ public class KafkaConfig {
                         kafkaProperties.getEndringPaOppfolgingsBrukerTopic(),
                         kafkaProperties.getVedtakSendtTopic(),
                         kafkaProperties.getVedtakStatusEndringTopic(),
-                        kafkaProperties.getArenaVedtakTopic()
+                        kafkaProperties.getArenaVedtakTopic(),
+                        kafkaProperties.getInnsatsbehovOnPremTopic()
                 )
         );
 

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/KafkaProperties.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/KafkaProperties.java
@@ -15,4 +15,5 @@ public class KafkaProperties {
     String vedtakStatusEndringTopic;
     String arenaVedtakTopic;
     String innsatsbehovTopic;
+    String innsatsbehovOnPremTopic;
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -12,3 +12,4 @@ app.kafka.vedtakSendtTopic=vedtakSendtTopic
 app.kafka.vedtakStatusEndringTopic=vedtakStatusEndringTopic
 app.kafka.arenaVedtakTopic=arenaVedtakTopic
 app.kafka.innsatsbehovTopic=innsatsbehovTopic
+app.kafka.innsatsbehovOnPremTopic=innsatsbehovOnPremTopic

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,4 @@ app.kafka.vedtakSendtTopic=${VEDTAK_SENDT_TOPIC}
 app.kafka.vedtakStatusEndringTopic=${VEDTAK_STATUS_ENDRING_TOPIC}
 app.kafka.arenaVedtakTopic=${ARENA_VEDTAK_TOPIC}
 app.kafka.innsatsbehovTopic=pto.innsatsbehov-v1
+app.kafka.innsatsbehovOnPremTopic=${INNSATSBEHOV_TOPIC}


### PR DESCRIPTION
Fortsetter produsering on prem i deploy-vindu, slik at det ikke ligger igjen uprosesserte meldinger i kafka_producer_record-tabellen for on prem topic.