### PR TITLE
Fikser og forenkler logikk for behandling av Arena vedtak

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/ArenaVedtak.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/ArenaVedtak.kt
@@ -76,8 +76,8 @@ data class ArenaVedtak(
 
     /**
      * Siden ArenaVedtak.fraDato har ikke tid, så brukes ArenaVedtak.operationTimestamp fra Kafka-melding til å legge på
-     * tid for å kunne finne ut hvilket vedtak som er det nyeste dersom det på samme dag fattes flere vedtak i Arena og
-     * eventuelt i denne løsningen, for samme bruker.
+     * tid for å kunne finne ut hvilket vedtak som er det nyeste dersom det på samme dag fattes vedtak både i Arena og i
+     * denne løsningen, for samme bruker.
      */
     fun beregnetFattetTidspunkt(): LocalDateTime {
         if (operationTimestamp.toLocalDate().equals(fraDato)) {

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/ArenaVedtakService.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/ArenaVedtakService.java
@@ -63,17 +63,15 @@ public class ArenaVedtakService {
 
         ArenaVedtak eksisterendeVedtak = arenaVedtakRepository.hentVedtak(arenaVedtak.getFnr());
 
-        if (eksisterendeVedtak != null && (
-                eksisterendeVedtak.getHendelseId() == arenaVedtak.getHendelseId() ||
-                        eksisterendeVedtak.beregnetFattetTidspunkt().isAfter(arenaVedtak.beregnetFattetTidspunkt())
-        )
+        if (eksisterendeVedtak != null &&
+                eksisterendeVedtak.getHendelseId() >= arenaVedtak.getHendelseId()
         ) {
-            log.info("Oppdaterer ikke vedtak fra Arena med hendelsesId={} og beregnetFattetTidspunkt={}. " +
-                            "Har allerede lagret Arena vedtak med hendelsesId={} og beregnetFattetTidspunkt={}",
+            log.info("Oppdaterer ikke vedtak fra Arena med hendelseId={} og fraDato={}. " +
+                            "Har allerede lagret Arena vedtak med hendelseId={} og fraDato={}",
                     arenaVedtak.getHendelseId(),
-                    arenaVedtak.beregnetFattetTidspunkt(),
+                    arenaVedtak.getFraDato(),
                     eksisterendeVedtak.getHendelseId(),
-                    eksisterendeVedtak.beregnetFattetTidspunkt()
+                    eksisterendeVedtak.getFraDato()
             );
             return false;
         }

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/ArenaVedtakServiceTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/ArenaVedtakServiceTest.java
@@ -89,7 +89,7 @@ public class ArenaVedtakServiceTest extends DatabaseTest {
     }
 
     @Test
-    public void behandleVedtakFraArena__overskriver_lagret_vedtak_med_vedtak_som_har_nyere_fra_dato() {
+    public void behandleVedtakFraArena__overskriver_lagret_vedtak_med_vedtak_som_har_nyere_hendelse_id() {
         Fnr fnr = Fnr.of(randomNumeric(10));
         ArenaVedtak arenaVedtak1 = new ArenaVedtak(
                 fnr,
@@ -97,43 +97,7 @@ public class ArenaVedtakServiceTest extends DatabaseTest {
                 ArenaVedtak.ArenaHovedmal.BEHOLDEA,
                 LocalDate.now(),
                 "reg user",
-                LocalDateTime.now().plusDays(3),
-                1234,
-                1
-        );
-
-        ArenaVedtak arenaVedtak2 = new ArenaVedtak(
-                fnr,
-                ArenaVedtak.ArenaInnsatsgruppe.BFORM,
-                ArenaVedtak.ArenaHovedmal.SKAFFEA,
-                arenaVedtak1.getFraDato().plusDays(1),
-                "reg user",
-                arenaVedtak1.getOperationTimestamp(),
-                4321,
-                1
-
-        );
-
-        assertTrue(service.behandleVedtakFraArena(arenaVedtak1));
-        assertTrue(service.behandleVedtakFraArena(arenaVedtak2));
-
-        ArenaVedtak lagretArenaVedtak = arenaVedtakRepository.hentVedtak(fnr);
-
-
-        assertEquals(arenaVedtak2, lagretArenaVedtak);
-        assertNotEquals(arenaVedtak1, lagretArenaVedtak);
-    }
-
-    @Test
-    public void behandleVedtakFraArena__overskriver_lagret_vedtak_med_vedtak_som_har_nyere_operation_timestamp() {
-        Fnr fnr = Fnr.of(randomNumeric(10));
-        ArenaVedtak arenaVedtak1 = new ArenaVedtak(
-                fnr,
-                ArenaVedtak.ArenaInnsatsgruppe.BATT,
-                ArenaVedtak.ArenaHovedmal.BEHOLDEA,
-                LocalDate.now(),
-                "reg user",
-                LocalDateTime.now(),
+                LocalDate.now().atStartOfDay(),
                 1234,
                 1
         );
@@ -144,8 +108,8 @@ public class ArenaVedtakServiceTest extends DatabaseTest {
                 ArenaVedtak.ArenaHovedmal.SKAFFEA,
                 arenaVedtak1.getFraDato(),
                 "reg user",
-                arenaVedtak1.getOperationTimestamp().plusMinutes(1),
-                4321,
+                arenaVedtak1.getOperationTimestamp(),
+                1235,
                 1
 
         );
@@ -180,7 +144,7 @@ public class ArenaVedtakServiceTest extends DatabaseTest {
     }
 
     @Test
-    public void behandleVedtakFraArena__overskriver_ikke_lagret_vedtak_med_vedtak_som_har_lik_dato_og_lik_hendelses_id() {
+    public void behandleVedtakFraArena__overskriver_ikke_lagret_vedtak_med_vedtak_som_har_lik_hendelses_id() {
         Fnr fnr = Fnr.of(randomNumeric(10));
         ArenaVedtak arenaVedtak1 = new ArenaVedtak(
                 fnr,
@@ -215,7 +179,7 @@ public class ArenaVedtakServiceTest extends DatabaseTest {
     }
 
     @Test
-    public void behandleVedtakFraArena__overskriver_lagret_vedtak_med_vedtak_som_har_lik_dato_og_ulik_hendelses_id() {
+    public void behandleVedtakFraArena__overskriver_lagret_vedtak_med_vedtak_som_har_lik_dato_og_hoyere_hendelses_id() {
         Fnr fnr = Fnr.of(randomNumeric(10));
         ArenaVedtak arenaVedtak1 = new ArenaVedtak(
                 fnr,
@@ -282,76 +246,6 @@ public class ArenaVedtakServiceTest extends DatabaseTest {
 
         assertEquals(arenaVedtak1, lagretArenaVedtak);
         assertNotEquals(arenaVedtak2, lagretArenaVedtak);
-    }
-
-    @Test
-    public void behandleVedtakFraArena__overskriver_ikke_lagret_vedtak_med_vedtak_som_har_fra_eldre_dato() {
-        Fnr fnr = Fnr.of(randomNumeric(10));
-        ArenaVedtak arenaVedtak1 = new ArenaVedtak(
-                fnr,
-                ArenaVedtak.ArenaInnsatsgruppe.BATT,
-                ArenaVedtak.ArenaHovedmal.BEHOLDEA,
-                LocalDate.now(),
-                "reg user",
-                LocalDateTime.now(),
-                12345,
-                1
-        );
-
-        ArenaVedtak arenaVedtak2 = new ArenaVedtak(
-                fnr,
-                ArenaVedtak.ArenaInnsatsgruppe.BFORM,
-                ArenaVedtak.ArenaHovedmal.SKAFFEA,
-                arenaVedtak1.getFraDato().minusDays(1),
-                "reg user",
-                arenaVedtak1.getOperationTimestamp(),
-                12346,
-                1
-        );
-
-        assertTrue(service.behandleVedtakFraArena(arenaVedtak1));
-        assertFalse(service.behandleVedtakFraArena(arenaVedtak2));
-
-        ArenaVedtak lagretArenaVedtak = arenaVedtakRepository.hentVedtak(fnr);
-
-
-        assertNotEquals(arenaVedtak2, lagretArenaVedtak);
-        assertEquals(arenaVedtak1, lagretArenaVedtak);
-    }
-
-    @Test
-    public void behandleVedtakFraArena__overskriver_ikke_lagret_vedtak_med_vedtak_som_har_eldre_operation_timestamp() {
-        Fnr fnr = Fnr.of(randomNumeric(10));
-        ArenaVedtak arenaVedtak1 = new ArenaVedtak(
-                fnr,
-                ArenaVedtak.ArenaInnsatsgruppe.BATT,
-                ArenaVedtak.ArenaHovedmal.BEHOLDEA,
-                LocalDate.now(),
-                "reg user",
-                LocalDateTime.now(),
-                12345,
-                1
-        );
-
-        ArenaVedtak arenaVedtak2 = new ArenaVedtak(
-                fnr,
-                ArenaVedtak.ArenaInnsatsgruppe.BFORM,
-                ArenaVedtak.ArenaHovedmal.SKAFFEA,
-                arenaVedtak1.getFraDato(),
-                "reg user",
-                arenaVedtak1.getOperationTimestamp().minusMinutes(1),
-                12346,
-                1
-        );
-
-        assertTrue(service.behandleVedtakFraArena(arenaVedtak1));
-        assertFalse(service.behandleVedtakFraArena(arenaVedtak2));
-
-        ArenaVedtak lagretArenaVedtak = arenaVedtakRepository.hentVedtak(fnr);
-
-
-        assertNotEquals(arenaVedtak2, lagretArenaVedtak);
-        assertEquals(arenaVedtak1, lagretArenaVedtak);
     }
 
     private Journalpost lagJournalpost(String tittel) {

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/Siste14aVedtakServiceTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/Siste14aVedtakServiceTest.kt
@@ -499,7 +499,8 @@ class Siste14aVedtakServiceTest : DatabaseTest() {
                 fnr = identer.fnr,
                 fraDato = fattetDato,
                 innsatsgruppe = ArenaInnsatsgruppe.BFORM,
-                hovedmal = ArenaHovedmal.OKEDELT
+                hovedmal = ArenaHovedmal.OKEDELT,
+                hendelseId = 6
             )
         )
 
@@ -510,7 +511,8 @@ class Siste14aVedtakServiceTest : DatabaseTest() {
                 fnr = identer.fnr,
                 fraDato = LocalDate.now().minusDays(1),
                 innsatsgruppe = ArenaInnsatsgruppe.IKVAL,
-                hovedmal = ArenaHovedmal.SKAFFEA
+                hovedmal = ArenaHovedmal.SKAFFEA,
+                hendelseId = 5
             )
         )
 


### PR DESCRIPTION
Bruker kun hendelse id for å avgjøre om et vedtak fra Arena er nyere enn et annet vedtak fra Arena. Tidligere logikk med beregnet fattet tidspunkt kan bli feil dersom meldinger sendes på nytt slik at det ikke er mulig å beregne fattet tidspunkt (blir da kl. 00:00).