### PR TITLE
Migrering for å sette default verdi til dokument_bestilling_id

### DIFF
--- a/src/main/resources/db/migration/V32__marker_distribuerte_dokument.sql
+++ b/src/main/resources/db/migration/V32__marker_distribuerte_dokument.sql
@@ -1,0 +1,8 @@
+UPDATE vedtak
+SET dokument_bestilling_id = '-'
+WHERE vedtak_fattet IS NOT NULL
+  AND status = 'SENDT'
+  AND dokument_bestilling_id IS NULL
+  AND journalpost_id IS NOT NULL
+  AND dokument_id IS NOT NULL
+  AND vedtak_fattet < '2022-03-04';


### PR DESCRIPTION
Gammel integrasjon mot brevløsning gir ikke tilbake dokumentbestilling-id, derfor settes denne verdien til '-' for vedtak der brev er sendt med gammel integrasjon, før kodeendring som gjorde at '-' settes programmatisk. Dette for å tilrettelegge støtte for ny dok.integrasjon med asynkron distribusjon av vedtak basert på fattede vedtak som mangler dokument_bestilling_id.