### PR TITLE
Håndterer statuskode 409 CONFLICT fra dokarkiv

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/dokdistfordeling/DokdistribusjonClientImpl.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/dokdistfordeling/DokdistribusjonClientImpl.kt
@@ -53,8 +53,8 @@ class DokdistribusjonClientImpl(
     fun throwIfNotSuccessful(response: Response) {
         if (response.code == HttpStatus.CONFLICT.value()) {
             log.warn(
-                "Status 409 i respons fra distribuerjournalpost: Vedtaket er allerede distribuert. " +
-                        "Forsøker å lagre bestillingsId fra respons."
+                "Status 409 CONFLICT i respons fra distribuerjournalpost: Vedtaket er allerede distribuert. " +
+                        "Forsøker å hente bestillingsId fra respons."
             )
         } else {
             RestUtils.throwIfNotSuccessful(response)


### PR DESCRIPTION
Dersom vedtaket allerede er journalført så svarer dokarkiv med status 409 CONFLICT og returnerer samme responsobjekt som ved 201 CREATED.