### PR TITLE
Refaktorer hva som skjer i VedtakStatusEndringService

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/domain/kafka/KafkaVedtakStatusEndring.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/domain/kafka/KafkaVedtakStatusEndring.java
@@ -19,6 +19,22 @@ public class KafkaVedtakStatusEndring {
 
     LocalDateTime timestamp;
 
+    public long getVedtakId() {
+        return this.vedtakId;
+    }
+
+    public String getAktorId() {
+        return this.aktorId;
+    }
+
+    public VedtakStatusEndring getVedtakStatusEndring() {
+        return this.vedtakStatusEndring;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return this.timestamp;
+    }
+
     @Data
     public static class UtkastOpprettet extends KafkaVedtakStatusEndring {
         public UtkastOpprettet() { vedtakStatusEndring = VedtakStatusEndring.UTKAST_OPPRETTET; }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/DvhRapporteringService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/DvhRapporteringService.kt
@@ -1,0 +1,21 @@
+package no.nav.veilarbvedtaksstotte.service
+
+import no.nav.veilarbvedtaksstotte.domain.kafka.KafkaVedtakStatusEndring
+import no.nav.veilarbvedtaksstotte.domain.kafka.VedtakStatusEndring.VEDTAK_SENDT
+import no.nav.veilarbvedtaksstotte.repository.VedtaksstotteRepository
+import org.springframework.stereotype.Service
+
+@Service
+class DvhRapporteringService(
+    private val vedtaksstotteRepository: VedtaksstotteRepository,
+    private val kafkaProducerService: KafkaProducerService
+) {
+
+    fun rapporterTilDvh(statusEndring: KafkaVedtakStatusEndring) {
+        if (statusEndring.vedtakStatusEndring == VEDTAK_SENDT) {
+            val vedtak = vedtaksstotteRepository.hentVedtak(statusEndring.vedtakId)
+
+            kafkaProducerService.sendVedtakFattetDvh(vedtak)
+        }
+    }
+}

--- a/src/test/java/no/nav/veilarbvedtaksstotte/config/ServiceTestConfig.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/config/ServiceTestConfig.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Import;
         MetricsService.class,
         OyeblikksbildeService.class,
         VedtakService.class,
-        VedtakStatusEndringService.class,
+        VedtakHendelserService.class,
         VeilarbarenaService.class,
         VeilederService.class,
         DokumentService.class,
@@ -26,7 +26,8 @@ import org.springframework.context.annotation.Import;
         Siste14aVedtakService.class,
         KafkaProducerService.class,
         KafkaConsumerService.class,
-        KafkaRepubliseringService.class
+        KafkaRepubliseringService.class,
+        DvhRapporteringService.class
 })
 public class ServiceTestConfig {
 }

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/BeslutterServiceTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/BeslutterServiceTest.java
@@ -29,7 +29,7 @@ public class BeslutterServiceTest {
 
     private final VedtaksstotteRepository vedtaksstotteRepository = mock(VedtaksstotteRepository.class);
 
-    private final VedtakStatusEndringService vedtakStatusEndringService = mock(VedtakStatusEndringService.class);
+    private final VedtakHendelserService vedtakStatusEndringService = mock(VedtakHendelserService.class);
 
     private final BeslutteroversiktRepository beslutteroversiktRepository = mock(BeslutteroversiktRepository.class);
 
@@ -39,6 +39,8 @@ public class BeslutterServiceTest {
 
     private final VeilarbpersonClient veilarbpersonClient = mock(VeilarbpersonClient.class);
 
+    private final MetricsService metricsService = mock(MetricsService.class);
+
     private final AuthService authService = mock(AuthService.class);
 
     private final JdbcTemplate db = SingletonPostgresContainer.init().createJdbcTemplate();
@@ -46,8 +48,8 @@ public class BeslutterServiceTest {
     private TransactionTemplate transactor = new TransactionTemplate(new DataSourceTransactionManager(db.getDataSource()));
 
     private BeslutterService beslutterService = new BeslutterService(
-            authService, vedtaksstotteRepository, vedtakStatusEndringService,
-            beslutteroversiktRepository, meldingRepository, veilederService, veilarbpersonClient, transactor
+            authService, vedtaksstotteRepository, vedtakStatusEndringService, beslutteroversiktRepository,
+            meldingRepository, veilederService, veilarbpersonClient, transactor, metricsService
     );
 
     @BeforeEach

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
@@ -69,7 +69,7 @@ public class VedtakServiceTest extends DatabaseTest {
     private static AuthService authService;
 
     private static final UnleashService unleashService = mock(UnleashService.class);
-    private static final VedtakStatusEndringService vedtakStatusEndringService = mock(VedtakStatusEndringService.class);
+    private static final VedtakHendelserService vedtakHendelserService = mock(VedtakHendelserService.class);
     private static final VeilederService veilederService = mock(VeilederService.class);
 
     private static final VeilarbpersonClient veilarbpersonClient = mock(VeilarbpersonClient.class);
@@ -84,6 +84,7 @@ public class VedtakServiceTest extends DatabaseTest {
     private static final VeilarbveilederClient veilarbveilederClient = mock(VeilarbveilederClient.class);
     private static final UtrullingService utrullingService = mock(UtrullingService.class);
     private static final EnhetInfoService enhetInfoService = mock(EnhetInfoService.class);
+    private static final MetricsService metricsService = mock(MetricsService.class);
 
     private static final VeilarbPep veilarbPep = mock(VeilarbPep.class);
 
@@ -122,9 +123,10 @@ public class VedtakServiceTest extends DatabaseTest {
                 authService,
                 oyeblikksbildeService,
                 veilederService,
-                vedtakStatusEndringService,
+                vedtakHendelserService,
                 dokumentService,
-                veilarbarenaService);
+                veilarbarenaService,
+                metricsService);
     }
 
     @BeforeEach
@@ -134,7 +136,7 @@ public class VedtakServiceTest extends DatabaseTest {
         reset(meldingRepository);
         reset(unleashService);
         reset(dokarkivClient);
-        reset(vedtakStatusEndringService);
+        reset(vedtakHendelserService);
         doReturn(TEST_VEILEDER_IDENT).when(authService).getInnloggetVeilederIdent();
         when(veilederService.hentEnhetNavn(TEST_OPPFOLGINGSENHET_ID)).thenReturn(TEST_OPPFOLGINGSENHET_NAVN);
         when(veilederService.hentVeileder(TEST_VEILEDER_IDENT)).thenReturn(new Veileder(TEST_VEILEDER_IDENT, TEST_VEILEDER_NAVN));
@@ -504,7 +506,7 @@ public class VedtakServiceTest extends DatabaseTest {
             assertEquals(TEST_JOURNALPOST_ID, sendtVedtak.getJournalpostId());
             assertOyeblikksbildeForFattetVedtak(sendtVedtak.getId());
         });
-        verify(vedtakStatusEndringService).vedtakSendt(any(), any());
+        verify(vedtakHendelserService).vedtakSendt(any());
     }
 
     private void assertOyeblikksbildeForFattetVedtak(long vedtakId) {


### PR DESCRIPTION
- Rename VedtakStatusEndringService til VedtakHendelserService
- Flytt ut metrikker fra VedtakHendelserService så den kun har ansvar for å sende Kafka-meldinger
- Flytter ut sending på Kafka-topic for DVH i egen service, DvhRapporteringService, for å tilrettelegge for å gjøre dette asynkront med bedre feilhåndtering