### PR TITLE
Endrer metrikk for alarm

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/metrics/DokumentdistribusjonMeterBinder.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/metrics/DokumentdistribusjonMeterBinder.kt
@@ -24,9 +24,9 @@ class DokumentdistribusjonMeterBinder(
 
     fun antallJournalforteVedtakUtenDokumentbestilling(): Int {
         return vedtaksstotteRepository.hentAntallJournalforteVedtakUtenDokumentbestilling(
-            // Trekker fra tid distribusjon schedule kjører (hvert 10. min) + 2 min unngå å telle med vedtak som holder
+            // Trekker fra tid distribusjon schedule kjører (hvert 10. min) + 3 min unngå å telle med vedtak som holder
             // på å bli distribuert
-            LocalDateTime.now().minusMinutes(12)
+            LocalDateTime.now().minusMinutes(13)
         )
     }
 

--- a/src/test/java/no/nav/veilarbvedtaksstotte/metrics/DokumentdistribusjonMeterBinderTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/metrics/DokumentdistribusjonMeterBinderTest.kt
@@ -30,11 +30,11 @@ class DokumentdistribusjonMeterBinderTest : DatabaseTest() {
         // for kort tid siden:
         lagreVedtak(now, dokumentBestillingId = Uuid(randomNumeric(10)))
         lagreVedtak(now, dokumentBestillingId = null)
-        lagreVedtak(now.minusMinutes(12).plusSeconds(1), dokumentBestillingId = null)
+        lagreVedtak(now.minusMinutes(13).plusSeconds(1), dokumentBestillingId = null)
 
         // innenfor:
-        lagreVedtak(now.minusMinutes(12).minusSeconds(5), dokumentBestillingId = Uuid(randomNumeric(10)))
-        lagreVedtak(now.minusMinutes(12).minusSeconds(5), dokumentBestillingId = null)
+        lagreVedtak(now.minusMinutes(13).minusSeconds(5), dokumentBestillingId = Uuid(randomNumeric(10)))
+        lagreVedtak(now.minusMinutes(13).minusSeconds(5), dokumentBestillingId = null)
         lagreVedtak(now.minusDays(2), dokumentBestillingId = Uuid(randomNumeric(10)))
         lagreVedtak(now.minusDays(2), dokumentBestillingId = null)
 


### PR DESCRIPTION
Øker tid før et vedtak som er fattet blir talt med som ikke distribuert. For å unngå falsk alarm ved deploy av app.