### PR TITLE
Spesifiser miljø i serviceName kun i dev for SAF-klient

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/ClientConfig.java
@@ -121,8 +121,10 @@ public class ClientConfig {
     public SafClient safClient(OboContexService oboContexService) {
         DownstreamApi safClient = DownstreamAPIs.getSaf().invoke(isProduction() ? "prod-fss" : "dev-fss");
         Supplier<String> userTokenSupplier = oboContexService.userTokenSupplier(safClient);
+        String serviceNameForIngress = "saf";
+        
         return new SafClientImpl(
-                naisPreprodOrNaisAdeoIngress(safClient.serviceName, false),
+                naisPreprodOrNaisAdeoIngress(serviceNameForIngress, false),
                 userTokenSupplier
         );
     }
@@ -220,7 +222,7 @@ public class ClientConfig {
                 : createNaisPreprodIngressUrl(appName, "q1", withAppContextPath);
     }
 
-    private static String tokenScope(DownstreamApi downstreamApi){
+    private static String tokenScope(DownstreamApi downstreamApi) {
         return String.format("api://%s.%s.%s/.default", downstreamApi.cluster, downstreamApi.namespace, downstreamApi.serviceName);
     }
 }


### PR DESCRIPTION
Forrige "fiks" fungerte dårlig da vi plutselig fikk `saf-q1-q1` i ingressen. Håndterer dette i denne PR-en.