### PR TITLE
Fiks saf scope for dokdistfordeling

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/ClientConfig.java
@@ -169,10 +169,13 @@ public class ClientConfig {
                 ? createProdInternalIngressUrl(appName)
                 : createDevInternalIngressUrl(appName);
 
-        String clientCluster = isProduction() ? "prod-fss" : "dev-fss";
-        String tokenScope = String.format("api://%s.teamdokumenthandtering.saf/.default", clientCluster);
+        // dokdistfordeling bruker saf token scope
+        String safTokenScope =
+                isProduction()
+                        ? "api://prod-fss.teamdokumenthandtering.saf/.default"
+                        : "api://dev-fss.teamdokumenthandtering.saf-q1/.default";
 
-        return new DokdistribusjonClientImpl(url, () -> tokenClient.createMachineToMachineToken(tokenScope));
+        return new DokdistribusjonClientImpl(url, () -> tokenClient.createMachineToMachineToken(safTokenScope));
     }
 
     @Bean


### PR DESCRIPTION
dokdistfordeling (som brukes for distribusjon av dokumenter) krever token med scope for saf. saf endret tidligere navn på app for scope fra saf til saf-q1