### PR TITLE
Prodsetting: Kafka pa aiven endring pa avslutt oppfolging (#356)

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -48,7 +48,7 @@ spec:
     pool: nav-dev
   env:
     - name: ENDRING_PA_AVSLUTT_OPPFOLGING_TOPIC
-      value: aapen-fo-endringPaaAvsluttOppfolging-v1-q1
+      value: pto.oppfolging-avsluttet-v1
     - name: ENDRING_PA_OPPFOLGINGS_BRUKER_TOPIC
       value: pto.endring-paa-oppfolgingsbruker-v2
     - name: ARENA_VEDTAK_TOPIC

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -46,7 +46,7 @@ spec:
     pool: nav-prod
   env:
     - name: ENDRING_PA_AVSLUTT_OPPFOLGING_TOPIC
-      value: aapen-fo-endringPaaAvsluttOppfolging-v1-p
+      value: pto.oppfolging-avsluttet-v1
     - name: ENDRING_PA_OPPFOLGINGS_BRUKER_TOPIC
       value: pto.endring-paa-oppfolgingsbruker-v2
     - name: ARENA_VEDTAK_TOPIC

--- a/src/main/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepository.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepository.java
@@ -118,8 +118,8 @@ public class VedtaksstotteRepository {
         return queryForObjectOrNull(() -> db.queryForObject(sql, VedtaksstotteRepository::mapVedtak, aktorId.get(), VedtakStatus.SENDT.name()));
     }
 
-    public void settGjeldendeVedtakTilHistorisk(String aktorId) {
-       db.update("UPDATE VEDTAK SET GJELDENDE = false WHERE AKTOR_ID = ? AND GJELDENDE = true", aktorId);
+    public void settGjeldendeVedtakTilHistorisk(long vedtakID) {
+        db.update("UPDATE VEDTAK SET GJELDENDE = false WHERE ID = ? AND GJELDENDE = true", vedtakID);
     }
 
     public void oppdaterUtkast(long vedtakId, Vedtak vedtak) {

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakService.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakService.java
@@ -69,10 +69,11 @@ public class VedtakService {
         Vedtak gjeldendeVedtak = vedtaksstotteRepository.hentGjeldendeVedtak(vedtak.getAktorId());
         validerVedtakForFerdigstilling(vedtak, gjeldendeVedtak);
 
-        journalforOgFerdigstill(vedtak, authKontekst);
+
+        journalforOgFerdigstill(vedtak, gjeldendeVedtak, authKontekst);
     }
 
-    private void journalforOgFerdigstill(Vedtak vedtak, AuthKontekst authKontekst) {
+    private void journalforOgFerdigstill(Vedtak vedtak, Vedtak gjeldendevedtak, AuthKontekst authKontekst) {
         long vedtakId = vedtak.getId();
 
         oyeblikksbildeService.lagreOyeblikksbilde(authKontekst.getFnr(), vedtakId);
@@ -105,7 +106,9 @@ public class VedtakService {
         }
 
         transactor.executeWithoutResult(status -> {
-            vedtaksstotteRepository.settGjeldendeVedtakTilHistorisk(vedtak.getAktorId());
+            if (gjeldendevedtak != null) {
+                vedtaksstotteRepository.settGjeldendeVedtakTilHistorisk(gjeldendevedtak.getId());
+            }
             vedtaksstotteRepository.ferdigstillVedtak(vedtakId);
             beslutteroversiktRepository.slettBruker(vedtak.getId());
         });

--- a/src/test/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepositoryTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/repository/VedtaksstotteRepositoryTest.java
@@ -2,17 +2,23 @@ package no.nav.veilarbvedtaksstotte.repository;
 
 import no.nav.common.types.identer.AktorId;
 import no.nav.veilarbvedtaksstotte.domain.DistribusjonBestillingId;
+import no.nav.veilarbvedtaksstotte.domain.kafka.KafkaAvsluttOppfolging;
 import no.nav.veilarbvedtaksstotte.domain.vedtak.BeslutterProsessStatus;
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Hovedmal;
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Innsatsgruppe;
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Vedtak;
+import no.nav.veilarbvedtaksstotte.service.KafkaConsumerService;
+import no.nav.veilarbvedtaksstotte.service.Siste14aVedtakService;
 import no.nav.veilarbvedtaksstotte.utils.DatabaseTest;
 import no.nav.veilarbvedtaksstotte.utils.DbTestUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static no.nav.veilarbvedtaksstotte.domain.vedtak.BeslutterProsessStatus.GODKJENT_AV_BESLUTTER;
@@ -134,12 +140,14 @@ public class VedtaksstotteRepositoryTest extends DatabaseTest {
         utkast.setBegrunnelse(TEST_BEGRUNNELSE);
         utkast.setInnsatsgruppe(Innsatsgruppe.STANDARD_INNSATS);
         utkast.setHovedmal(Hovedmal.SKAFFE_ARBEID);
+        utkast.setVedtakFattet(LocalDateTime.now());
+
         vedtaksstotteRepository.oppdaterUtkast(utkast.getId(), utkast);
         kilderRepository.lagKilder(TEST_KILDER, utkast.getId());
 
         vedtaksstotteRepository.ferdigstillVedtak(utkast.getId());
 
-        vedtaksstotteRepository.settGjeldendeVedtakTilHistorisk(TEST_AKTOR_ID);
+        vedtaksstotteRepository.settGjeldendeVedtakTilHistorisk(utkast.getId());
 
         Vedtak fattetVedtak = vedtaksstotteRepository.hentVedtak(utkast.getId());
 

--- a/src/test/java/no/nav/veilarbvedtaksstotte/utils/AbstractVedtakIntegrationTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/utils/AbstractVedtakIntegrationTest.kt
@@ -49,7 +49,8 @@ abstract class AbstractVedtakIntegrationTest {
         gjeldende: Boolean = true,
         enhetId: String = "1234",
         veilederIdent: String = "VIDENT",
-        beslutterIdent: String? = null
+        beslutterIdent: String? = null,
+        gammelVedtakId: Long = 1234
     ): Vedtak {
         vedtakRepository.opprettUtkast(
             aktorId.get(), TestData.TEST_VEILEDER_IDENT, TestData.TEST_OPPFOLGINGSENHET_ID
@@ -58,7 +59,8 @@ abstract class AbstractVedtakIntegrationTest {
         vedtak.innsatsgruppe = innsatsgruppe
         vedtak.hovedmal = hovedmal
         vedtakRepository.oppdaterUtkast(vedtak.id, vedtak)
-        vedtakRepository.settGjeldendeVedtakTilHistorisk(aktorId.get())
+        vedtakRepository.hentGjeldendeVedtak(aktorId.get())
+            ?.also { vedtakRepository.settGjeldendeVedtakTilHistorisk(it.id) }
         vedtakRepository.ferdigstillVedtak(vedtak.id)
         jdbcTemplate.update(
             """


### PR DESCRIPTION
Endret fra onprem-topic aapen-fo-endringPaaAvsluttOppfolging-v1-q1 til Aiven topic pto.oppfolging-avsluttet-v1 i dev. Siden topicen ikke er idempotent måtte vi legge inn en datosjekk. Når vi leser alle meldingene på nytt, vil vi kun lese meldinger om oppfolging avsluttet. Dette vil kunne føre til at vi setter vedtak som er fattet etter oppf avsluttet til historiske. Vi må derfor sjekke datoen vedtaket er fattet opp mot datoen for avslutt oppfolging, og kun sette vedtaket til historisk dersom det er fattet før oppf avsluttet.


Co-authored-by: Oda Dahlen <oda.dahlen@bekk.no>
Co-authored-by: Sondre Larsen Ovrid <sondre.larsen.ovrid@nav.no>