### PR TITLE
Prodsette: TC-320 Gi alle AzureAD-brukere tilgang i prod (#375)

### DIFF
--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -59,6 +59,7 @@ spec:
       value: api://prod-gcp.poao.poao-tilgang/.default
   azure:
     application:
+      allowAllUsers: true
       enabled: true
       claims:
         extra:


### PR DESCRIPTION
Ref. endring i default brukertilganger for AzureAD, som annonsert i #nais-announcements: https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619