### PR TITLE
Logg konsumenter som bruker fnr i path-/query-params

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/CustomWebMvcConfigurer.java
@@ -1,0 +1,26 @@
+package no.nav.veilarbvedtaksstotte.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    private final FnrUsageLoggerInterceptor fnrUsageLoggerInterceptor;
+
+    @Autowired
+    public CustomWebMvcConfigurer(final FnrUsageLoggerInterceptor fnrUsageLoggerInterceptor) {
+        this.fnrUsageLoggerInterceptor = fnrUsageLoggerInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        List<String> excludePaths = List.of("/internal", "/internal/**");
+
+        registry.addInterceptor(fnrUsageLoggerInterceptor).excludePathPatterns(excludePaths);
+    }
+}

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/FnrUsageLoggerInterceptor.java
@@ -1,0 +1,30 @@
+package no.nav.veilarbvedtaksstotte.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.common.utils.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@Slf4j
+public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) {
+        String requestURI = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fnrPattern = ".*\\b\\d{11}\\b.*";
+
+        boolean hasFnrInRequestURI = StringUtils.notNullOrEmpty(requestURI) && requestURI.matches(fnrPattern);
+        boolean hasFnrInQueryString = StringUtils.notNullOrEmpty(queryString) && queryString.matches(fnrPattern);
+
+        if (hasFnrInRequestURI || hasFnrInQueryString) {
+            log.info("Konsument forespurte endepunkt som matcher fnr-regex.");
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Legger til funksjonalitet for å sjekke og eventuelt logge en beskjed dersom vi har konsumenter som går mot endepunkter i applikasjonen som inneholder fnr-parametre (path-params eller query-params). Sjekken er veldig enkel/dum og ser bare på henholdsvis URIen og query-stringen og sjekker om de inneholder en sekvens av elleve siffer.

Bruker `HandlerInterceptor`-konseptet til dette formålet slik at vi kan sette opp sjekken _en_ plass. Registrerer `FnrUsageLoggerInterceptor` i `InterceptorRegistry`-et til Spring slik at requester til appen blir sendt gjennom sjekken gitt i `preHandle`-metoden (se forøvrig: [Spring MVC HandlerInterceptor vs Filter: Key differences and use-cases](https://www.baeldung.com/spring-mvc-handlerinterceptor-vs-filter#key-differences-and-use-cases)).

Tanken er å bruke dette til å visualisere bruken av utdaterte endepunkter med fnr i path-/query-params i arbeidet med å migrere over til nye endepunkter.