### PR TITLE
Bytt til poao-baseimages som base for Docker-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/pus-nais-java-app/pus-nais-java-app:java17
+FROM ghcr.io/navikt/poao-baseimages/java:17
 COPY /target/veilarbvedtaksstotte.jar app.jar


### PR DESCRIPTION
`pus-nais-java-app`-imagene har ikke vært vedlikeholdt på en stund, så derfor bumper vi til `poao-baseimages`-image.

Dette skal ikke medføre noen endringer for applikasjonen, med unntak av det faktum at `poao-baseimages`ikke har enablet AppDynamics. Applikasjonen vil derfor slutte å rapportere metrikker dit. AppDynamics er derimot ikke støttet i GCP og har EOL ved utgangen av 2024, så dette er noe vi uansett må kvitte oss med.