### PR TITLE
TC-579 Gi token-generator tilgang i dev

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -91,6 +91,9 @@ spec:
         - application: pto-admin
           namespace: pto
           cluster: dev-fss
+        - application: azure-token-generator
+          namespace: aura
+          cluster: dev-gcp
     outbound:
       external:
         - host: team-obo-unleash-web.nav.cloud.nais.io


### PR DESCRIPTION
Gir token-generator tilgang i dev slik at vi kan generere access-tokens on-demand.

Fra [NAIS-docen](https://doc.nais.io/security/auth/azure-ad/usage/#token-generator):

> In many cases, you want to locally develop and test against a secured API in the development environments. To do so, you need a [token](https://doc.nais.io/security/auth/concepts/#bearer-token) to access said API.