### PR TITLE
Fjern protokoll fra "host" da det ikke er tillatt

### DIFF
--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -103,7 +103,7 @@ spec:
           cluster: prod-gcp
       external:
         - host: team-obo-unleash-web.nav.cloud.nais.io
-        - host: https://www.nav.no/aia-backend
+        - host: www.nav.no/aia-backend
   envFrom:
     - configmap: pto-config
     - secret: veilarbvedtaksstotte-unleash-api-token


### PR DESCRIPTION
Ref: https://doc.nav.cloud.nais.io/reference/application-spec/#accesspolicyoutboundexternalhost