### PR TITLE
Bytt til ny springdoc-komponent som støtter Spring Boot versjon 3.x.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.7.0</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
Ser ut som springdoc-swagger genereringen sluttet å virke når vi gikk over til Spring Boot 3.x.x. Med ny springdoc-komponent skal det fungere igjen, ref: https://stackoverflow.com/a/75789657.

Verifisert i dev.