### PR TITLE
Utvide hent siste 14a vedtak for eksterne brukere

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -67,6 +67,8 @@ spec:
         extra:
           - NAVident
           - azp_name
+  tokenx:
+    enabled: true
   accessPolicy:
     inbound:
       rules:

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -65,6 +65,8 @@ spec:
         extra:
           - NAVident
           - azp_name
+  tokenx:
+    enabled: true
   accessPolicy:
     inbound:
       rules:

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/EnvironmentProperties.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/EnvironmentProperties.kt
@@ -20,4 +20,6 @@ data class EnvironmentProperties (
     val poaoTilgangUrl: String,
     val poaoTilgangScope: String,
     val aiaBackendUrl: String,
+    val tokenxDiscoveryUrl: String,
+    val tokenxClientId: String
 )

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/FilterConfig.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/FilterConfig.java
@@ -1,5 +1,6 @@
 package no.nav.veilarbvedtaksstotte.config;
 
+import no.nav.common.auth.context.UserRole;
 import no.nav.common.auth.oidc.filter.AzureAdUserRoleResolver;
 import no.nav.common.auth.oidc.filter.OidcAuthenticationFilter;
 import no.nav.common.auth.oidc.filter.OidcAuthenticatorConfig;
@@ -23,6 +24,13 @@ public class FilterConfig {
                 .withUserRoleResolver(new AzureAdUserRoleResolver());
     }
 
+    private OidcAuthenticatorConfig tokenxAuthConfig(EnvironmentProperties properties) {
+        return new OidcAuthenticatorConfig()
+                .withDiscoveryUrl(properties.getTokenxDiscoveryUrl())
+                .withClientId(properties.getTokenxClientId())
+                .withUserRole(UserRole.EKSTERN);
+    }
+
     @Bean
     public FilterRegistrationBean<LogRequestFilter>  logFilterRegistrationBean() {
         FilterRegistrationBean<LogRequestFilter> registration = new FilterRegistrationBean<>();
@@ -36,7 +44,10 @@ public class FilterConfig {
     public FilterRegistrationBean<OidcAuthenticationFilter> authenticationFilterRegistrationBean(EnvironmentProperties properties) {
         FilterRegistrationBean<OidcAuthenticationFilter> registration = new FilterRegistrationBean<>();
         OidcAuthenticationFilter authenticationFilter = new OidcAuthenticationFilter(
-                fromConfigs(azureAdAuthConfig(properties))
+                fromConfigs(
+                        azureAdAuthConfig(properties),
+                        tokenxAuthConfig(properties)
+                )
         );
 
         registration.setFilter(authenticationFilter);

--- a/src/main/java/no/nav/veilarbvedtaksstotte/controller/Siste14aVedtakController.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/controller/Siste14aVedtakController.kt
@@ -33,7 +33,7 @@ class Siste14aVedtakController(
                 throw ResponseStatusException(HttpStatus.FORBIDDEN);
             }
         } else {
-            authService.sjekkTilgangTilBruker(fnr)
+            authService.sjekkVeilederTilgangTilBruker(fnr)
         }
     }
 }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2Controller.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2Controller.kt
@@ -30,7 +30,7 @@ class Siste14aVedtakV2Controller(
                 throw ResponseStatusException(HttpStatus.FORBIDDEN)
             }
         } else {
-            authService.sjekkTilgangTilBruker(fnr)
+            authService.sjekkVeilederTilgangTilBruker(fnr)
         }
     }
 }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2Controller.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2Controller.kt
@@ -29,7 +29,10 @@ class Siste14aVedtakV2Controller(
             if (!authService.harSystemTilSystemTilgangMedEkstraRolle("siste-14a-vedtak")) {
                 throw ResponseStatusException(HttpStatus.FORBIDDEN)
             }
-        } else {
+        } else if (authService.erEksternBruker()) {
+            authService.sjekkEksternbrukerTilgangTilBruker(fnr)
+        }
+        else {
             authService.sjekkVeilederTilgangTilBruker(fnr)
         }
     }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/AuthService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/AuthService.kt
@@ -48,12 +48,12 @@ class AuthService(
     private val unleashService: DefaultUnleash
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    fun sjekkTilgangTilBruker(fnr: Fnr) {
-        sjekkTilgangTilBruker({ fnr }) { aktorOppslagClient.hentAktorId(fnr) }
+    fun sjekkVeilederTilgangTilBruker(fnr: Fnr) {
+        sjekkVeilederTilgangTilBruker({ fnr }) { aktorOppslagClient.hentAktorId(fnr) }
     }
 
-    fun sjekkTilgangTilBruker(aktorId: AktorId) {
-        sjekkTilgangTilBruker({ aktorOppslagClient.hentFnr(aktorId) }) { aktorId }
+    fun sjekkVeilederTilgangTilBruker(aktorId: AktorId) {
+        sjekkVeilederTilgangTilBruker({ aktorOppslagClient.hentFnr(aktorId) }) { aktorId }
     }
 
     fun sjekkTilgangTilBrukerOgEnhet(fnr: Fnr): AuthKontekst {
@@ -64,7 +64,7 @@ class AuthService(
         return sjekkTilgangTilBrukerOgEnhet({ aktorOppslagClient.hentFnr(aktorId) }) { aktorId }
     }
 
-    private fun sjekkTilgangTilBruker(
+    private fun sjekkVeilederTilgangTilBruker(
         fnrSupplier: Supplier<Fnr>,
         aktorIdSupplier: Supplier<AktorId>
     ): Pair<Fnr, AktorId> {
@@ -92,7 +92,7 @@ class AuthService(
         fnrSupplier: Supplier<Fnr>,
         aktorIdSupplier: Supplier<AktorId>
     ): AuthKontekst {
-        val fnrAktorIdPair = sjekkTilgangTilBruker(fnrSupplier, aktorIdSupplier)
+        val fnrAktorIdPair = sjekkVeilederTilgangTilBruker(fnrSupplier, aktorIdSupplier)
         val fnr = fnrAktorIdPair.first
         val aktorId = fnrAktorIdPair.second
         val enhet = sjekkTilgangTilEnhet(fnr.get())
@@ -209,6 +209,10 @@ class AuthService(
 
     fun erSystemBruker(): Boolean {
         return authContextHolder.erSystemBruker()
+    }
+
+    fun erEksternBruker(): Boolean {
+        return authContextHolder.erEksternBruker()
     }
 
     fun harSystemTilSystemTilgang(): Boolean {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,8 @@ app.env.norg2Url=${NORG2_URL:#{null}}
 app.env.poaoTilgangUrl=${POAO_TILGANG_URL:#{null}}
 app.env.poaoTilgangScope=${POAO_TILGANG_SCOPE:#{null}}
 app.env.aiaBackendUrl=${AIA_BACKEND_URL:#{null}}
+app.env.tokenxClientId=${TOKEN_X_CLIENT_ID:null}
+app.env.tokenxDiscoveryUrl=${TOKEN_X_WELL_KNOWN_URL:null}
 
 # Nais variabler
 app.env.naisAadDiscoveryUrl=${AZURE_APP_WELL_KNOWN_URL:#{null}}

--- a/src/test/java/no/nav/veilarbvedtaksstotte/controller/Siste14aVedtakControllerTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/controller/Siste14aVedtakControllerTest.kt
@@ -81,7 +81,7 @@ class Siste14aVedtakControllerTest {
         } returns false
 
         every {
-            authService.sjekkTilgangTilBruker(fnr)
+            authService.sjekkVeilederTilgangTilBruker(fnr)
         } answers { }
 
         val response = mockMvc.perform(MockMvcRequestBuilders.get("/api/siste-14a-vedtak").queryParam("fnr", fnr.get()))
@@ -98,7 +98,7 @@ class Siste14aVedtakControllerTest {
         } returns false
 
         every {
-            authService.sjekkTilgangTilBruker(fnr)
+            authService.sjekkVeilederTilgangTilBruker(fnr)
         } throws ResponseStatusException(HttpStatus.FORBIDDEN)
 
         val response = mockMvc.perform(MockMvcRequestBuilders.get("/api/siste-14a-vedtak").queryParam("fnr", fnr.get()))

--- a/src/test/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2ControllerTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2ControllerTest.kt
@@ -92,6 +92,10 @@ class Siste14aVedtakV2ControllerTest {
         } returns false
 
         every {
+            authService.erEksternBruker()
+        } returns false
+
+        every {
             authService.sjekkVeilederTilgangTilBruker(fnr)
         } answers { }
 
@@ -108,6 +112,10 @@ class Siste14aVedtakV2ControllerTest {
 
         every {
             authService.erSystemBruker()
+        } returns false
+
+        every {
+            authService.erEksternBruker()
         } returns false
 
         every {

--- a/src/test/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2ControllerTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2ControllerTest.kt
@@ -92,7 +92,7 @@ class Siste14aVedtakV2ControllerTest {
         } returns false
 
         every {
-            authService.sjekkTilgangTilBruker(fnr)
+            authService.sjekkVeilederTilgangTilBruker(fnr)
         } answers { }
 
         val response = mockMvc.perform(post("/api/v2/hent-siste-14a-vedtak")
@@ -111,7 +111,7 @@ class Siste14aVedtakV2ControllerTest {
         } returns false
 
         every {
-            authService.sjekkTilgangTilBruker(fnr)
+            authService.sjekkVeilederTilgangTilBruker(fnr)
         } throws ResponseStatusException(HttpStatus.FORBIDDEN)
 
         val response = mockMvc.perform(post("/api/v2/hent-siste-14a-vedtak")

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/AuthServiceTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/AuthServiceTest.kt
@@ -60,7 +60,7 @@ class AuthServiceTest {
         whenever(
             poaoTilgangClient.evaluatePolicy(org.mockito.kotlin.any())
         ).thenReturn(ApiResult.success(Decision.Permit))
-        withContext(UserRole.INTERN) { authService.sjekkTilgangTilBruker(TestData.TEST_FNR) }
+        withContext(UserRole.INTERN) { authService.sjekkVeilederTilgangTilBruker(TestData.TEST_FNR) }
     }
 
     @Test
@@ -73,7 +73,7 @@ class AuthServiceTest {
         UserRole.values().filter { userRole: UserRole -> userRole != UserRole.INTERN }.forEach { userRole: UserRole ->
                 withContext(userRole) {
                     assertThrowsWithMessage<ResponseStatusException>("""403 FORBIDDEN "Ikke intern bruker"""") {
-                        authService.sjekkTilgangTilBruker(TestData.TEST_FNR)
+                        authService.sjekkVeilederTilgangTilBruker(TestData.TEST_FNR)
                     }
                 }
             }
@@ -91,7 +91,7 @@ class AuthServiceTest {
         ).thenReturn(ApiResult.success(Decision.Deny("","")))
         withContext(UserRole.INTERN) {
             assertThrowsWithMessage<ResponseStatusException>("403 FORBIDDEN") {
-                authService.sjekkTilgangTilBruker(TestData.TEST_FNR)
+                authService.sjekkVeilederTilgangTilBruker(TestData.TEST_FNR)
             }
         }
     }
@@ -105,7 +105,7 @@ class AuthServiceTest {
             poaoTilgangClient.evaluatePolicy(org.mockito.kotlin.any())
         ).thenReturn(ApiResult.success(Decision.Permit))
         withContext(UserRole.INTERN) {
-                authService.sjekkTilgangTilBruker(TestData.TEST_FNR)
+                authService.sjekkVeilederTilgangTilBruker(TestData.TEST_FNR)
         }
         org.mockito.kotlin.verify(poaoTilgangClient, times(1)).evaluatePolicy(org.mockito.kotlin.any())
     }
@@ -117,7 +117,7 @@ class AuthServiceTest {
         ).thenReturn(ApiResult.success(Decision.Deny("","")))
         withContext(UserRole.INTERN) {
             assertThrowsWithMessage<ResponseStatusException>("403 FORBIDDEN") {
-                authService.sjekkTilgangTilBruker(TestData.TEST_FNR)
+                authService.sjekkVeilederTilgangTilBruker(TestData.TEST_FNR)
             }
         }
         org.mockito.kotlin.verify(poaoTilgangClient, times(1)).evaluatePolicy(org.mockito.kotlin.any())


### PR DESCRIPTION
Vi utvider /hent-siste-14avedtak endepunktet til å kunne akseptere spørringer fra eksterne brukere med tokenX og sikkerhetslevel 4 (Idporten).

Begrunnelsen for dette er at team paw trenger å kunne vise på "Ditt NAV" om bruker har et vedtak eller ikke. I stedenfor at de skal spørre med systembruker og at vi har mindre oversikt over hvorfor kallet gjøres er det mer hensiktsmessig at vi får kallet direkte fra bruker og kan verifisere at bruker kun kan spørre om sitt eget vedtak.  