### PR TITLE
Splitte Swagger-docen i to grupperingar: ein for "interne"- og ein for "eksterne"-endepunkt

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/annotations/EndepunktKlassifiseringAnnotation.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/annotations/EndepunktKlassifiseringAnnotation.kt
@@ -1,0 +1,10 @@
+package no.nav.veilarbvedtaksstotte.annotations
+
+
+/**
+ * Markerer et endepunkt som et eksternt endepunkt.
+ * Det vil si, endepunkt kan brukes både internt i egne applikasjoner og av eksterne konsumenter.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EksterntEndepunkt

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/SwaggerConfig.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/SwaggerConfig.kt
@@ -1,0 +1,61 @@
+package no.nav.veilarbvedtaksstotte.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import no.nav.veilarbvedtaksstotte.annotations.EksterntEndepunkt
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+
+    /**
+     * Lager en gruppering kalt "Eksterne endepunkter (for konsumenter)" i Swagger-doc.
+     * Grupperingen inneholder alle endepunkter som er annotert med [EksterntEndepunkt].
+     */
+    @Bean
+    fun externalApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("Eksterne endepunkter (for konsumenter)")
+            .addOperationCustomizer { operation, handlerMethod ->
+                if (handlerMethod.method.getAnnotation(EksterntEndepunkt::class.java) != null) {
+                    operation
+                } else {
+                    null
+                }
+            }
+            .addOpenApiCustomizer(removeEmptyTags())
+            .build()
+    }
+
+    /**
+     * Lager en gruppering kalt "Interne endepunkter" i Swagger-doc.
+     * Grupperingen inneholder alle endepunkter.
+     */
+    @Bean
+    fun internalApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("Interne endepunkter")
+            .addOpenApiCustomizer(removeEmptyTags())
+            .build()
+    }
+
+    /**
+     * For å unngå at vi får tomme "seksjoner" i Swagger-doc, fjerner vi tags som ikke er i bruk.
+     * Klasser annotert med [io.swagger.v3.oas.annotations.tags.Tag] vil få en egen seksjon i Swagger-doc.
+     * Siden vi per dags dato blander eksterne/interne endepunkter i samme controller, må vi eksplisitt gjøre denne filtreringen.
+     *
+     * Denne trenger vi foreløpig kun å bruke i [externalApi], siden [internalApi] uansett inneholder alle endepunkter.
+     */
+    @Bean
+    fun removeEmptyTags(): OpenApiCustomizer {
+        return OpenApiCustomizer { openApi: OpenAPI ->
+            val usedTags = openApi.paths.values
+                .flatMap { pathItem -> pathItem.readOperations().flatMap { it.tags } }
+                .toSet()
+            openApi.tags = openApi.tags?.filter { it.name in usedTags }
+        }
+    }
+}

--- a/src/main/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2Controller.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/controller/v2/Siste14aVedtakV2Controller.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.common.types.identer.Fnr
+import no.nav.veilarbvedtaksstotte.annotations.EksterntEndepunkt
 import no.nav.veilarbvedtaksstotte.controller.dto.Siste14aVedtakDTO
 import no.nav.veilarbvedtaksstotte.controller.v2.dto.Siste14aVedtakRequest
 import no.nav.veilarbvedtaksstotte.service.AuthService
@@ -28,6 +29,7 @@ class Siste14aVedtakV2Controller(
     val siste14aVedtakService: Siste14aVedtakService
 ) {
 
+    @EksterntEndepunkt
     @PostMapping("/hent-siste-14a-vedtak")
     @Operation(
         summary = "Hent siste 14a vedtak",


### PR DESCRIPTION
Lagar ein custom annotasjon, `@EksterntEndepunkt`, som vi kan legge på alle endepunkt vi tenker det er hensiktsmessig at eksterne konsumentar kan bruke.

Sjå eksempel her for korleis dette blir sjåandes ut: https://veilarbvedtaksstotte.intern.dev.nav.no/veilarbvedtaksstotte/internal/swagger-ui/index.html?urls.primaryName=Eksterne+endepunkter+(for+konsumenter)
_Hint: i dropdown-en "Select a definition" kan ein velje mellom å sjå høvesvis interne og eksterne endepunkt._