### PR TITLE
Inkludere "OKE_DELTAKELSE" i kodeverket, for bakoverkompatibilitet med Arena

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/controller/dto/Siste14aVedtakDTO.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/controller/dto/Siste14aVedtakDTO.kt
@@ -1,12 +1,13 @@
 package no.nav.veilarbvedtaksstotte.controller.dto
 
+import no.nav.veilarbvedtaksstotte.domain.vedtak.HovedmalMedOkeDeltakelse
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Innsatsgruppe
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak
 import java.time.ZonedDateTime
 
 data class Siste14aVedtakDTO(
     val innsatsgruppe: Innsatsgruppe,
-    val hovedmal: Siste14aVedtak.HovedmalMedOkeDeltakelse?,
+    val hovedmal: HovedmalMedOkeDeltakelse?,
     val fattetDato: ZonedDateTime,
     val fraArena: Boolean
 ) {

--- a/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/HovedmalDetaljert.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/HovedmalDetaljert.java
@@ -5,15 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum HovedmalDetaljert {
-    SKAFFE_ARBEID(Hovedmal.SKAFFE_ARBEID, "Skaffe arbeid"),
-    BEHOLDE_ARBEID(Hovedmal.BEHOLDE_ARBEID, "Beholde arbeid");
+    SKAFFE_ARBEID(HovedmalMedOkeDeltakelse.SKAFFE_ARBEID, "Skaffe arbeid"),
+    BEHOLDE_ARBEID(HovedmalMedOkeDeltakelse.BEHOLDE_ARBEID, "Beholde arbeid"),
+    OKE_DELTAKELSE(HovedmalMedOkeDeltakelse.OKE_DELTAKELSE, "Øke deltakelse");
 
     @JsonProperty("kode")
-    Hovedmal kode;
+    HovedmalMedOkeDeltakelse kode;
     @JsonProperty("beskrivelse")
     String beskrivelse;
 
-    HovedmalDetaljert(Hovedmal kode, String beskrivelse) {
+    HovedmalDetaljert(HovedmalMedOkeDeltakelse kode, String beskrivelse) {
         this.kode = kode;
         this.beskrivelse = beskrivelse;
     }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/HovedmalMedOkeDeltakelse.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/HovedmalMedOkeDeltakelse.kt
@@ -1,0 +1,26 @@
+package no.nav.veilarbvedtaksstotte.domain.vedtak
+
+// Må ha med OKE_DELTAKELSE for bakoverkompabilitet på vedtak fra Arena.
+enum class HovedmalMedOkeDeltakelse {
+    SKAFFE_ARBEID, BEHOLDE_ARBEID, OKE_DELTAKELSE;
+
+    companion object {
+        @JvmStatic
+        fun fraHovedmal(hovedmal: Hovedmal?): HovedmalMedOkeDeltakelse? =
+            when (hovedmal) {
+                Hovedmal.SKAFFE_ARBEID -> SKAFFE_ARBEID
+                Hovedmal.BEHOLDE_ARBEID -> BEHOLDE_ARBEID
+                null -> null
+            }
+
+        @JvmStatic
+        fun fraArenaHovedmal(arenaHovedmal: ArenaVedtak.ArenaHovedmal?): HovedmalMedOkeDeltakelse? =
+            when (arenaHovedmal) {
+                ArenaVedtak.ArenaHovedmal.SKAFFEA -> SKAFFE_ARBEID
+                ArenaVedtak.ArenaHovedmal.BEHOLDEA -> BEHOLDE_ARBEID
+                ArenaVedtak.ArenaHovedmal.OKEDELT -> OKE_DELTAKELSE
+                null -> null
+            }
+    }
+
+}

--- a/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/Siste14aVedtak.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/domain/vedtak/Siste14aVedtak.kt
@@ -1,7 +1,6 @@
 package no.nav.veilarbvedtaksstotte.domain.vedtak
 
 import no.nav.common.types.identer.AktorId
-import no.nav.veilarbvedtaksstotte.domain.vedtak.ArenaVedtak.ArenaHovedmal
 import java.time.ZonedDateTime
 
 data class Siste14aVedtak(
@@ -12,28 +11,4 @@ data class Siste14aVedtak(
     val fraArena: Boolean
 ) {
 
-    // Må ha med OKE_DELTAKELSE for bakoverkompabilitet på vedtak fra Arena.
-    enum class HovedmalMedOkeDeltakelse {
-        SKAFFE_ARBEID, BEHOLDE_ARBEID, OKE_DELTAKELSE;
-
-        companion object {
-            @JvmStatic
-            fun fraHovedmal(hovedmal: Hovedmal?): HovedmalMedOkeDeltakelse? =
-                when (hovedmal) {
-                    Hovedmal.SKAFFE_ARBEID -> SKAFFE_ARBEID
-                    Hovedmal.BEHOLDE_ARBEID -> BEHOLDE_ARBEID
-                    null -> null
-                }
-
-            @JvmStatic
-            fun fraArenaHovedmal(arenaHovedmal: ArenaHovedmal?): HovedmalMedOkeDeltakelse? =
-                when (arenaHovedmal) {
-                    ArenaHovedmal.SKAFFEA -> SKAFFE_ARBEID
-                    ArenaHovedmal.BEHOLDEA -> BEHOLDE_ARBEID
-                    ArenaHovedmal.OKEDELT -> OKE_DELTAKELSE
-                    null -> null
-                }
-        }
-
-    }
 }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/Siste14aVedtakService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/Siste14aVedtakService.kt
@@ -7,7 +7,7 @@ import no.nav.common.utils.EnvironmentUtils.isDevelopment
 import no.nav.veilarbvedtaksstotte.domain.vedtak.ArenaVedtak
 import no.nav.veilarbvedtaksstotte.domain.vedtak.ArenaVedtak.ArenaInnsatsgruppe
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak
-import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak.HovedmalMedOkeDeltakelse
+import no.nav.veilarbvedtaksstotte.domain.vedtak.HovedmalMedOkeDeltakelse
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Vedtak
 import no.nav.veilarbvedtaksstotte.repository.ArenaVedtakRepository
 import no.nav.veilarbvedtaksstotte.repository.VedtaksstotteRepository

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakHendelserService.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/VedtakHendelserService.java
@@ -7,6 +7,7 @@ import no.nav.veilarbvedtaksstotte.client.veilederogenhet.dto.Veileder;
 import no.nav.veilarbvedtaksstotte.domain.kafka.KafkaVedtakSendt;
 import no.nav.veilarbvedtaksstotte.domain.kafka.KafkaVedtakStatusEndring;
 import no.nav.veilarbvedtaksstotte.domain.kafka.VedtakStatusEndring;
+import no.nav.veilarbvedtaksstotte.domain.vedtak.HovedmalMedOkeDeltakelse;
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak;
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Vedtak;
 import no.nav.veilarbvedtaksstotte.repository.VedtaksstotteRepository;
@@ -114,7 +115,7 @@ public class VedtakHendelserService {
                 new Siste14aVedtak(
                         AktorId.of(vedtak.getAktorId()),
                         vedtak.getInnsatsgruppe(),
-                        Siste14aVedtak.HovedmalMedOkeDeltakelse.fraHovedmal(vedtak.getHovedmal()),
+                        HovedmalMedOkeDeltakelse.fraHovedmal(vedtak.getHovedmal()),
                         toZonedDateTime(vedtak.getVedtakFattet()),
                         false));
     }

--- a/src/test/java/no/nav/veilarbvedtaksstotte/kafka/Siste14aVedtakKafkaProducerTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/kafka/Siste14aVedtakKafkaProducerTest.kt
@@ -7,7 +7,7 @@ import no.nav.veilarbvedtaksstotte.config.KafkaProperties
 import no.nav.veilarbvedtaksstotte.domain.vedtak.ArenaVedtak
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Innsatsgruppe
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak
-import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak.HovedmalMedOkeDeltakelse.SKAFFE_ARBEID
+import no.nav.veilarbvedtaksstotte.domain.vedtak.HovedmalMedOkeDeltakelse.SKAFFE_ARBEID
 import no.nav.veilarbvedtaksstotte.service.Siste14aVedtakService
 import no.nav.veilarbvedtaksstotte.utils.AbstractVedtakIntegrationTest
 import no.nav.veilarbvedtaksstotte.utils.KafkaTestUtils

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/KafkaProducerServiceTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/KafkaProducerServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.veilarbvedtaksstotte.domain.vedtak.Hovedmal.BEHOLDE_ARBEID
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Innsatsgruppe.SPESIELT_TILPASSET_INNSATS
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Innsatsgruppe.STANDARD_INNSATS
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak
-import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak.HovedmalMedOkeDeltakelse.SKAFFE_ARBEID
+import no.nav.veilarbvedtaksstotte.domain.vedtak.HovedmalMedOkeDeltakelse.SKAFFE_ARBEID
 import no.nav.veilarbvedtaksstotte.utils.JsonUtils
 import no.nav.veilarbvedtaksstotte.utils.TestData.TEST_AKTOR_ID
 import no.nav.veilarbvedtaksstotte.utils.TestData.TEST_OPPFOLGINGSENHET_ID

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/Siste14aVedtakServiceTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/Siste14aVedtakServiceTest.kt
@@ -6,7 +6,7 @@ import no.nav.veilarbvedtaksstotte.domain.vedtak.ArenaVedtak.ArenaInnsatsgruppe
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Hovedmal
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Innsatsgruppe
 import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak
-import no.nav.veilarbvedtaksstotte.domain.vedtak.Siste14aVedtak.HovedmalMedOkeDeltakelse
+import no.nav.veilarbvedtaksstotte.domain.vedtak.HovedmalMedOkeDeltakelse
 import no.nav.veilarbvedtaksstotte.utils.AbstractVedtakIntegrationTest
 import no.nav.veilarbvedtaksstotte.utils.TimeUtils.now
 import no.nav.veilarbvedtaksstotte.utils.TimeUtils.toZonedDateTime


### PR DESCRIPTION
Vi har konsumentar som kjem til å benytte seg av `/api/siste-14a-vedtak`-endepunktet. Dette endepunktet inneheld vedtak frå både ny vedtaksløysing _og_ Arena.

Per i dag støttar vi ikkje `OKE_DELTAKELSE`-hovedmålet i kodeverket, som er kjipt for konsumentar som ønskjer å nytte kodeverket vårt, f.eks. `/open/api/kodeverk/innsatsgruppeoghovedmal`, for å mappe frå `hovedmal` til visningsverdiar.

Byttar difor frå `Hovedmal` til `Siste14aVedtak.HovedmalMedOkeDeltakelse`-typen samt legg til mapping for `OKE_DELTAKELSE`.