### PR TITLE
Fjern caching av oppfolgingsbruker for hent-tilhorerBrukerUtrulletKontor

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/arena/VeilarbarenaClient.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/arena/VeilarbarenaClient.java
@@ -10,6 +10,7 @@ public interface VeilarbarenaClient extends HealthCheck {
 
     Optional<VeilarbArenaOppfolging> hentOppfolgingsbruker(Fnr fnr);
 
-    Optional<String> oppfolgingssak(Fnr fnr);
+    Optional<VeilarbArenaOppfolging> hentOppfolgingsbrukerUtenCache(Fnr fnr);
 
+    Optional<String> oppfolgingssak(Fnr fnr);
 }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/arena/VeilarbarenaClientImpl.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/arena/VeilarbarenaClientImpl.java
@@ -42,6 +42,14 @@ public class VeilarbarenaClientImpl implements VeilarbarenaClient {
 
     @Cacheable(CacheConfig.ARENA_BRUKER_CACHE_NAME)
     public Optional<VeilarbArenaOppfolging> hentOppfolgingsbruker(Fnr fnr) {
+        return hentOppfolgingsbrukerIntern(fnr);
+    }
+
+    public Optional<VeilarbArenaOppfolging> hentOppfolgingsbrukerUtenCache(Fnr fnr) {
+        return hentOppfolgingsbrukerIntern(fnr);
+    }
+
+    private Optional<VeilarbArenaOppfolging> hentOppfolgingsbrukerIntern(Fnr fnr) {
         Request request = new Request.Builder()
                 .url(joinPaths(veilarbarenaUrl, "/api/v3/hent-oppfolgingsbruker"))
                 .header(HttpHeaders.AUTHORIZATION, bearerToken(machineToMachineToken.get()))

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/UtrullingService.java
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/UtrullingService.java
@@ -60,7 +60,7 @@ public class UtrullingService {
 
     public boolean tilhorerBrukerUtrulletKontor(Fnr fnr) {
         try {
-            return veilarbarenaClient.hentOppfolgingsbruker(fnr)
+            return veilarbarenaClient.hentOppfolgingsbrukerUtenCache(fnr)
                     .map(VeilarbArenaOppfolging::getNavKontor)
                     .map(EnhetId::of)
                     .map(utrullingRepository::erUtrullet)

--- a/src/test/java/no/nav/veilarbvedtaksstotte/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/config/ClientTestConfig.java
@@ -151,6 +151,11 @@ public class ClientTestConfig {
             }
 
             @Override
+            public Optional<VeilarbArenaOppfolging> hentOppfolgingsbrukerUtenCache(Fnr fnr) {
+                return Optional.of(new VeilarbArenaOppfolging(TEST_OPPFOLGINGSENHET_ID, "ARBS", "IKVAL"));
+            }
+
+            @Override
             public Optional<String> oppfolgingssak(Fnr fnr) {
                 return Optional.of(TEST_OPPFOLGINGSSAK);
             }


### PR DESCRIPTION
Fiks som løser forsinkelse ved start av oppfølging via ny inngang.

Ved start av oppfølging for bruker tar det 1-2 min før bruker får tildelt enhet i Arena, og hvis man klikket seg inn på 14a vedtak i aktivitetsplanen før dette, så ble det cachet at bruker ikke hadde enhet.
Måtte da vente ~10 min før ny henting fra Arena ble gjort.
Ved at hent-tilhorerBrukerUtrulletKontor ikke cacher, unngår man forsinkelsesproblemet.