### PR TITLE
Gir komet tilgang til endepunkt for å hende gjeldende 14a vedtak

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -147,6 +147,8 @@ spec:
           permissions:
             roles:
               - "gjeldende-14a-vedtak"
+              - "siste-14a-vedtak"
+
         - application: modiapersonoversikt-api
           namespace: personoversikt
         - application: tiltaksgjennomforing-api

--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -146,7 +146,7 @@ spec:
           namespace: amt
           permissions:
             roles:
-              - "siste-14a-vedtak"
+              - "gjeldende-14a-vedtak"
         - application: modiapersonoversikt-api
           namespace: personoversikt
         - application: tiltaksgjennomforing-api

--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -148,7 +148,6 @@ spec:
             roles:
               - "gjeldende-14a-vedtak"
               - "siste-14a-vedtak"
-
         - application: modiapersonoversikt-api
           namespace: personoversikt
         - application: tiltaksgjennomforing-api

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -138,7 +138,7 @@ spec:
           namespace: amt
           permissions:
             roles:
-              - "siste-14a-vedtak"
+              - "gjeldende-14a-vedtak"
         # Lenke til behandling i Behandlingskatalogen: https://behandlingskatalog.intern.nav.no/process/team/7ec4b786-ddf7-4c56-ab2f-3c3edeb0d33f/4ff22ca5-c66a-4127-9271-9de34800c8dd
         - application: modiapersonoversikt-api
           namespace: personoversikt

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -139,6 +139,7 @@ spec:
           permissions:
             roles:
               - "gjeldende-14a-vedtak"
+              - "siste-14a-vedtak"
         # Lenke til behandling i Behandlingskatalogen: https://behandlingskatalog.intern.nav.no/process/team/7ec4b786-ddf7-4c56-ab2f-3c3edeb0d33f/4ff22ca5-c66a-4127-9271-9de34800c8dd
         - application: modiapersonoversikt-api
           namespace: personoversikt


### PR DESCRIPTION
For å rette feil i komets løsninger så trenger vi å hente gjeldende innsatsgruppe isteden for den siste

https://trello.com/c/s0YN7ag6/2202-vi-bruker-i-noen-tilfeller-feil-innsatsgruppe-for-p%C3%A5melding