### PR TITLE
Nedgraderer logback-pakker slik at vi får tilbake x_-tagger i loggene for lanseringsdagen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,26 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.12</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.12</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Har forsøkt å ha høyere versjoner men det går ikke helt uten videre. Nedgraderer derfor pakkene akkurat for lanseringsdagen, men jobber videre for å finne en mer permanent løsning på problemet.