### PR TITLE
Bruke machine-to-machine token for å hente navn ved journalføring

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/person/VeilarbpersonClient.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/person/VeilarbpersonClient.kt
@@ -9,6 +9,7 @@ import no.nav.veilarbvedtaksstotte.domain.Malform
 
 interface VeilarbpersonClient : HealthCheck {
     fun hentPersonNavn(fnr: String): PersonNavn
+    fun hentPersonNavnForJournalforing(fnr: String): PersonNavn
     fun hentCVOgJobbprofil(fnr: String): CvDto
     fun hentMalform(fnr: Fnr): Malform
     fun hentAdressebeskyttelse(fnr: Fnr): Adressebeskyttelse

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/DokumentService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/DokumentService.kt
@@ -174,7 +174,7 @@ class DokumentService(
 
     private fun lagProduserDokumentDTO(vedtak: Vedtak, fnr: Fnr, utkast: Boolean): ProduserDokumentDTO {
         val malType = malTypeService.utledMalTypeFraVedtak(vedtak, fnr)
-        val personnavn = veilarbpersonClient.hentPersonNavn(fnr.toString())
+        val personnavn = veilarbpersonClient.hentPersonNavnForJournalforing(fnr.toString())
         val navn = listOfNotNull(personnavn.fornavn, personnavn.mellomnavn, personnavn.etternavn).joinToString(" ")
 
 

--- a/src/test/java/no/nav/veilarbvedtaksstotte/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/config/ClientTestConfig.java
@@ -261,6 +261,17 @@ public class ClientTestConfig {
             }
 
             @Override
+            public PersonNavn hentPersonNavnForJournalforing(String fnr) {
+                PersonNavn personNavn = new PersonNavn(
+                        "TEST",
+                        null,
+                        "TESTERSEN",
+                        "TEST TESTERSEN"
+                );
+                return personNavn;
+            }
+
+            @Override
             public CvDto hentCVOgJobbprofil(String fnr) {
                 return new CvDto.CvMedError(CvErrorStatus.IKKE_DELT);
             }

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
@@ -195,6 +195,7 @@ public class VedtakServiceTest extends DatabaseTest {
         when(veilarbpersonClient.hentMalform(TEST_FNR)).thenReturn(Malform.NB);
         when(veilarbpersonClient.hentCVOgJobbprofil(TEST_FNR.get())).thenReturn(new CvDto.CVMedInnhold(JsonUtils.fromJson(testCvData(), CvInnhold.class)));
         when(veilarbpersonClient.hentPersonNavn(TEST_FNR.get())).thenReturn(new PersonNavn("Fornavn", null, "Etternavn", null));
+        when(veilarbpersonClient.hentPersonNavnForJournalforing(TEST_FNR.get())).thenReturn(new PersonNavn("Fornavn", null, "Etternavn", null));
         when(aia_backend_client.hentEgenvurdering(new EgenvurderingForPersonRequest(TEST_FNR.get()))).thenReturn(JsonUtils.fromJson(testEgenvurderingData(), EgenvurderingResponseDTO.class));
         when(aktorOppslagClient.hentAktorId(TEST_FNR)).thenReturn(AktorId.of(TEST_AKTOR_ID));
         when(aktorOppslagClient.hentFnr(AktorId.of(TEST_AKTOR_ID))).thenReturn(TEST_FNR);


### PR DESCRIPTION
Når et vedtak fattes forsøker vi å journalføre det. Dersom det feiler ved journalføring så blir det plukket opp på et senere tidspunkt av en batch-jobb og forsøkt journalført på nytt.

Vi hadde en feil der slike vedtak (som var forsøkt journalført og ble plukket opp av jobben) _ikke_ kunne journalføres. Rotårsaken var at ifm. journalføring forsøker vi å hente brukers navn (`VeilarbpersonClient.hentPersonNavn`), men med user-token. Det funker dårlig i en batch-jobb kontekst.