### PR TITLE
Legg til alarm for når distribusjon vert blokkert  av for mange feilande poster i utsendingskøen

### DIFF
--- a/.nais/alerts/alerts-config-prod.yaml
+++ b/.nais/alerts/alerts-config-prod.yaml
@@ -74,3 +74,24 @@ spec:
           labels:
             namespace: obo
             severity: critical
+
+        - alert: Køen for distribusjon av journalpost er over 50% full
+          expr: sum(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 100
+          for: 5m
+          annotations:
+            summary: "Over halvparten av plassene for batch-sending av vedtak blir fylt av journalposter der sending feiler."
+            action: "Veilarbvedtaksstotte sender 100 journalposter til distribuering om gangen, eldste først. Nå fylles over halvparten av disse plassene med journalposter der distribuering feiler. For å unngå at disse postene blokkerer all utsending må de fikses manuelt."
+          labels:
+            namespace: obo
+            severity: critical
+
+        - alert: Køen for distribusjon av journalposter er helt full
+          expr: sum(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 200
+          for: 5m
+          annotations:
+            summary: "Vedtak blir ikke distribuert fordi det er for mange journalposter der sending feiler"
+            action: "Veilarbvedtaksstotte sender 100 journalposter til distribuering om gangen, eldste først. Nå fylles alle disse plassene med journalposter der distribuering feiler. Feilen må rettes så fort som mulig, enten ved å fikse problemene med distribusjon, eller ved å øke batch-størrelsen. Dersom du er alene på jobb er det nå du ringer en venn."
+          labels:
+            namespace: obo
+            severity: critical
+            


### PR DESCRIPTION
Gjeldande batch-storleik: 100 meldingar.

Av ein eller annan grunn tel prometheus alle meldingane dobbelt, derav "> 100" for 50 meldingar og "> 200" for full kø.