### PR TITLE
Ikkje bruk "sum" på Gauge-metrikk då det gir feil totalantal

### DIFF
--- a/.nais/alerts/alerts-config-prod.yaml
+++ b/.nais/alerts/alerts-config-prod.yaml
@@ -46,7 +46,7 @@ spec:
 
         # Forretningsspesifikke alerts
         - alert: Fattet vedtak er ikke Journalført
-          expr: sum(antall_fattet_vedtak_uten_journalforing{app="veilarbvedtaksstotte"}) > 0
+          expr: max(antall_fattet_vedtak_uten_journalforing{app="veilarbvedtaksstotte"}) > 0
           for: 5m
           annotations:
             summary: "Det finnes fattet vedtak som ikke er journalført."
@@ -56,7 +56,7 @@ spec:
             severity: critical
 
         - alert: Journalførte dokument er ikke distribuert
-          expr: sum(antall_journalforte_vedtak_uten_dokumentbestilling{app="veilarbvedtaksstotte"}) > 0
+          expr: max(antall_journalforte_vedtak_uten_dokumentbestilling{app="veilarbvedtaksstotte"}) > 0
           for: 5m
           annotations:
             summary: "Det finnes journalført dokument som ikke er distribuert."
@@ -66,7 +66,7 @@ spec:
             severity: critical
 
         - alert: Distribusjon av journalpost har feilet
-          expr: sum(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 0
+          expr: max(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 0
           for: 5m
           annotations:
             summary: "Distribusjon av journalpost har feilet."
@@ -76,7 +76,7 @@ spec:
             severity: critical
 
         - alert: Køen for distribusjon av journalpost er over 50% full
-          expr: sum(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 100
+          expr: max(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 100
           for: 5m
           annotations:
             summary: "Over halvparten av plassene for batch-sending av vedtak blir fylt av journalposter der sending feiler."
@@ -86,7 +86,7 @@ spec:
             severity: critical
 
         - alert: Køen for distribusjon av journalposter er helt full
-          expr: sum(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 200
+          expr: max(antall_vedtak_med_feilende_dokumentbestilling{app="veilarbvedtaksstotte"}) > 200
           for: 5m
           annotations:
             summary: "Vedtak blir ikke distribuert fordi det er for mange journalposter der sending feiler"


### PR DESCRIPTION
Prometheus-metrikkane som desse alarmane er basert på er såkalla [Gauge-metrikkar](https://prometheus.io/docs/concepts/metric_types/#gauge). Sidan vi køyrer fleire pod-ar av appen vil alle pod-ane rapportere same talet for metrikkane. Når vi brukar `sum` så summerer vi på tvers av alle pod-ane, noko som gir feil totalantal sidan dei rapporterer det same talet. `max` fungerer betre til formålet då den returnerer det høgaste rapporterte talet. Det kan tenkast at pod_1 f.eks. er først ute, og så kjem pod_2 litt seinare og rapporterer same tal; då vil `max` gi oss indikasjon umiddelbart.