### PR TITLE
Legg til mottaker i oyeblikksbrevene

### DIFF
--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfClient.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfClient.kt
@@ -1,77 +1,11 @@
 package no.nav.veilarbvedtaksstotte.client.pdf
 
 import no.nav.common.health.HealthCheck
-import no.nav.common.types.identer.Fnr
-import no.nav.veilarbvedtaksstotte.client.arbeidssoekeregisteret.OpplysningerOmArbeidssoekerMedProfilering
-import no.nav.veilarbvedtaksstotte.client.dokument.MalType
-import no.nav.veilarbvedtaksstotte.client.person.dto.*
-import no.nav.veilarbvedtaksstotte.domain.Malform
-import no.nav.veilarbvedtaksstotte.domain.oyeblikksbilde.EgenvurderingDto
-import java.time.ZonedDateTime
 
 interface PdfClient : HealthCheck {
-    fun genererPdf(brevdata: Brevdata): ByteArray
-    fun genererOyeblikksbildeCvPdf(cvOyeblikksbildeData: CvInnholdMedMottaker): ByteArray
-    fun genererOyeblikksbildeEgenVurderingPdf(egenvurderingOyeblikksbildeData: EgenvurderingDto): ByteArray
-    fun genererOyeblikksbildeArbeidssokerRegistretPdf(registreringOyeblikksbildeData: OpplysningerOmArbeidssoekerMedProfilering): ByteArray
-
-
-    data class Brevdata(
-        val malType: MalType,
-        val veilederNavn: String,
-        val navKontor: String,
-        val dato: String,
-        val malform: Malform,
-        val begrunnelse: List<String>,
-        val kilder: List<String>,
-        val mottaker: Mottaker,
-        val utkast: Boolean,
-        val ungdomsgaranti: Boolean
-    )
-
-    data class Mottaker(
-        val navn: String,
-        val fodselsnummer: Fnr,
-    )
-
-    data class CvInnholdMedMottaker (
-        val mottaker: Mottaker,
-        val sistEndret: ZonedDateTime?,
-        val synligForArbeidsgiver: Boolean?,
-        val sistEndretAvNav: Boolean? = false,
-        val sammendrag: String?,
-        val arbeidserfaring: List<ArbeidserfaringDtoV2>?,
-        val utdanning: List<UtdanningDtoV2>?,
-        val fagdokumentasjoner: List<FagdokumentasjonDtoV2>?,
-        val godkjenninger: List<GodkjenningDtoV2>?,
-        val annenErfaring: List<AnnenErfaringDtoV2>?,
-        val forerkort: List<ForerkortDtoV2>?,
-        val kurs: List<KursDtoV2>?,
-        val sertifikater: List<SertifikatDtoV2>?,
-        val andreGodkjenninger: List<SertifikatDtoV2>?,
-        val sprak: List<SprakDtoV2>?,
-        val jobbprofil: FOJobbprofilDtoV2?
-    ) {
-        companion object {
-            fun from(cv: CvInnhold, mottaker: Mottaker) = CvInnholdMedMottaker(
-                mottaker = Mottaker(mottaker.navn, mottaker.fodselsnummer),
-                sistEndret = cv.sistEndret,
-                synligForArbeidsgiver = cv.synligForArbeidsgiver,
-                sistEndretAvNav = cv.sistEndretAvNav,
-                sammendrag = cv.sammendrag,
-                arbeidserfaring = cv.arbeidserfaring,
-                utdanning = cv.utdanning,
-                fagdokumentasjoner = cv.fagdokumentasjoner,
-                godkjenninger = cv.godkjenninger,
-                annenErfaring = cv.annenErfaring,
-                forerkort = cv.forerkort,
-                kurs = cv.kurs,
-                sertifikater = cv.sertifikater,
-                andreGodkjenninger = cv.andreGodkjenninger,
-                sprak = cv.sprak,
-                jobbprofil = cv.jobbprofil
-            )
-        }
-    }
+    fun genererPdf(brevdata: BrevdataDto): ByteArray
+    fun genererOyeblikksbildeCvPdf(cvOyeblikksbildeData: CvInnholdMedMottakerDto): ByteArray
+    fun genererOyeblikksbildeEgenVurderingPdf(egenvurderingOyeblikksbildeData: EgenvurderingMedMottakerDto): ByteArray
+    fun genererOyeblikksbildeArbeidssokerRegistretPdf(registreringOyeblikksbildeData: OpplysningerOmArbeidssoekerMedProfileringMedMottakerDto): ByteArray
 
 }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfClientImpl.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfClientImpl.kt
@@ -5,8 +5,6 @@ import no.nav.common.health.HealthCheckUtils
 import no.nav.common.rest.client.RestClient
 import no.nav.common.rest.client.RestUtils
 import no.nav.common.utils.UrlUtils.joinPaths
-import no.nav.veilarbvedtaksstotte.client.arbeidssoekeregisteret.OpplysningerOmArbeidssoekerMedProfilering
-import no.nav.veilarbvedtaksstotte.domain.oyeblikksbilde.EgenvurderingDto
 import no.nav.veilarbvedtaksstotte.domain.oyeblikksbilde.OyeblikksbildePdfTemplate
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -17,7 +15,7 @@ class PdfClientImpl(val pdfGenUrl: String) : PdfClient {
 
     val client: OkHttpClient = RestClient.baseClient()
 
-    override fun genererPdf(brevdata: PdfClient.Brevdata): ByteArray {
+    override fun genererPdf(brevdata: BrevdataDto): ByteArray {
 
         val request = Request.Builder()
             .url(joinPaths(pdfGenUrl, "api/v1/genpdf/vedtak14a/vedtak14a"))
@@ -41,7 +39,7 @@ class PdfClientImpl(val pdfGenUrl: String) : PdfClient {
     }
 
     override fun genererOyeblikksbildeCvPdf(
-        cvOyeblikksbildeData: PdfClient.CvInnholdMedMottaker,
+        cvOyeblikksbildeData: CvInnholdMedMottakerDto,
     ): ByteArray {
         val request = Request.Builder()
             .url(joinPaths(pdfGenUrl, "api/v1/genpdf/vedtak14a/" + OyeblikksbildePdfTemplate.CV_OG_JOBBPROFIL.templateName))
@@ -64,7 +62,7 @@ class PdfClientImpl(val pdfGenUrl: String) : PdfClient {
         }
     }
 
-    override fun genererOyeblikksbildeEgenVurderingPdf(egenvurderingOyeblikksbildeData: EgenvurderingDto): ByteArray {
+    override fun genererOyeblikksbildeEgenVurderingPdf(egenvurderingOyeblikksbildeData: EgenvurderingMedMottakerDto): ByteArray {
         val request = Request.Builder()
             .url(joinPaths(pdfGenUrl, "api/v1/genpdf/vedtak14a/" + OyeblikksbildePdfTemplate.EGENVURDERING.templateName))
             .post(RestUtils.toJsonRequestBody(egenvurderingOyeblikksbildeData))
@@ -86,7 +84,7 @@ class PdfClientImpl(val pdfGenUrl: String) : PdfClient {
         }
     }
 
-    override fun genererOyeblikksbildeArbeidssokerRegistretPdf(registreringOyeblikksbildeData: OpplysningerOmArbeidssoekerMedProfilering): ByteArray {
+    override fun genererOyeblikksbildeArbeidssokerRegistretPdf(registreringOyeblikksbildeData: OpplysningerOmArbeidssoekerMedProfileringMedMottakerDto): ByteArray {
         val request = Request.Builder()
             .url(joinPaths(pdfGenUrl, "api/v1/genpdf/vedtak14a/" + OyeblikksbildePdfTemplate.ARBEIDSSOKERREGISTRET.templateName))
             .post(RestUtils.toJsonRequestBody(registreringOyeblikksbildeData))

--- a/src/main/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfDomene.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfDomene.kt
@@ -1,0 +1,102 @@
+package no.nav.veilarbvedtaksstotte.client.pdf
+
+import no.nav.common.types.identer.Fnr
+import no.nav.veilarbvedtaksstotte.client.arbeidssoekeregisteret.OpplysningerOmArbeidssoekerMedProfilering
+import no.nav.veilarbvedtaksstotte.client.arbeidssoekeregisteret.OpplysningerOmArbeidssoekerResponse
+import no.nav.veilarbvedtaksstotte.client.arbeidssoekeregisteret.ProfileringResponse
+import no.nav.veilarbvedtaksstotte.client.dokument.MalType
+import no.nav.veilarbvedtaksstotte.client.person.dto.*
+import no.nav.veilarbvedtaksstotte.domain.Malform
+import no.nav.veilarbvedtaksstotte.domain.oyeblikksbilde.EgenvurderingDto
+import java.time.ZonedDateTime
+
+
+data class BrevdataDto(
+    val malType: MalType,
+    val veilederNavn: String,
+    val navKontor: String,
+    val dato: String,
+    val malform: Malform,
+    val begrunnelse: List<String>,
+    val kilder: List<String>,
+    val mottaker: Mottaker,
+    val utkast: Boolean,
+    val ungdomsgaranti: Boolean
+)
+
+data class Mottaker(
+    val navn: String,
+    val fodselsnummer: Fnr,
+)
+
+data class CvInnholdMedMottakerDto(
+    val mottaker: Mottaker,
+    val sistEndret: ZonedDateTime?,
+    val synligForArbeidsgiver: Boolean?,
+    val sistEndretAvNav: Boolean? = false,
+    val sammendrag: String?,
+    val arbeidserfaring: List<ArbeidserfaringDtoV2>?,
+    val utdanning: List<UtdanningDtoV2>?,
+    val fagdokumentasjoner: List<FagdokumentasjonDtoV2>?,
+    val godkjenninger: List<GodkjenningDtoV2>?,
+    val annenErfaring: List<AnnenErfaringDtoV2>?,
+    val forerkort: List<ForerkortDtoV2>?,
+    val kurs: List<KursDtoV2>?,
+    val sertifikater: List<SertifikatDtoV2>?,
+    val andreGodkjenninger: List<SertifikatDtoV2>?,
+    val sprak: List<SprakDtoV2>?,
+    val jobbprofil: FOJobbprofilDtoV2?
+) {
+    companion object {
+        fun from(cv: CvInnhold, mottaker: Mottaker) = CvInnholdMedMottakerDto(
+            mottaker = Mottaker(mottaker.navn, mottaker.fodselsnummer),
+            sistEndret = cv.sistEndret,
+            synligForArbeidsgiver = cv.synligForArbeidsgiver,
+            sistEndretAvNav = cv.sistEndretAvNav,
+            sammendrag = cv.sammendrag,
+            arbeidserfaring = cv.arbeidserfaring,
+            utdanning = cv.utdanning,
+            fagdokumentasjoner = cv.fagdokumentasjoner,
+            godkjenninger = cv.godkjenninger,
+            annenErfaring = cv.annenErfaring,
+            forerkort = cv.forerkort,
+            kurs = cv.kurs,
+            sertifikater = cv.sertifikater,
+            andreGodkjenninger = cv.andreGodkjenninger,
+            sprak = cv.sprak,
+            jobbprofil = cv.jobbprofil
+        )
+    }
+}
+
+data class EgenvurderingMedMottakerDto(
+    val mottaker: Mottaker,
+    val sistOppdatert: String? = null,
+    val svar: List<EgenvurderingDto.Svar>? = null
+) {
+    companion object {
+        fun from(egenvurdering: EgenvurderingDto, mottaker: Mottaker) = EgenvurderingMedMottakerDto(
+            mottaker = mottaker,
+            sistOppdatert = egenvurdering.sistOppdatert,
+            svar = egenvurdering.svar
+        )
+    }
+}
+
+data class OpplysningerOmArbeidssoekerMedProfileringMedMottakerDto(
+    val mottaker: Mottaker,
+    val opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoekerResponse? = null,
+    val profilering: ProfileringResponse? = null,
+    val arbeidssoekerperiodeStartet: ZonedDateTime? = null
+) {
+    companion object {
+        fun from(registreringsdata: OpplysningerOmArbeidssoekerMedProfilering, mottaker: Mottaker) =
+            OpplysningerOmArbeidssoekerMedProfileringMedMottakerDto(
+                mottaker = mottaker,
+                opplysningerOmArbeidssoeker = registreringsdata.opplysningerOmArbeidssoeker,
+                profilering = registreringsdata.profilering,
+                arbeidssoekerperiodeStartet = registreringsdata.arbeidssoekerperiodeStartet
+            )
+    }
+}
+

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/DokumentService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/DokumentService.kt
@@ -9,7 +9,8 @@ import no.nav.veilarbvedtaksstotte.client.dokarkiv.request.OpprettetJournalpostD
 import no.nav.veilarbvedtaksstotte.client.dokument.MalType
 import no.nav.veilarbvedtaksstotte.client.dokument.ProduserDokumentDTO
 import no.nav.veilarbvedtaksstotte.client.norg2.EnhetKontaktinformasjon
-import no.nav.veilarbvedtaksstotte.client.pdf.PdfClient
+import no.nav.veilarbvedtaksstotte.client.pdf.BrevdataDto
+import no.nav.veilarbvedtaksstotte.client.pdf.Mottaker
 import no.nav.veilarbvedtaksstotte.client.person.VeilarbpersonClient
 import no.nav.veilarbvedtaksstotte.client.person.dto.FodselsdatoOgAr
 import no.nav.veilarbvedtaksstotte.client.veilarboppfolging.VeilarboppfolgingClient
@@ -48,6 +49,7 @@ class DokumentService(
         val produserDokumentDTO = lagProduserDokumentDTO(vedtak = vedtak, fnr = fnr, utkast = false)
         val dokument = pdfService.produserDokument(produserDokumentDTO)
         val tittel = "Vurdering av ditt behov for oppfølging fra NAV"
+        val mottaker = Mottaker(produserDokumentDTO.navn, fnr)
 
         val oppfolgingsperiode = veilarboppfolgingClient.hentGjeldendeOppfolgingsperiode(fnr)
         val oppfolgingssak = veilarboppfolgingClient.hentOppfolgingsperiodeSak(oppfolgingsperiode.get().uuid)
@@ -63,9 +65,9 @@ class DokumentService(
         val arbeidssokerRegistretData =
             oyeblikksbildeForVedtak.firstOrNull { it.oyeblikksbildeType == OyeblikksbildeType.ARBEIDSSOKERREGISTRET }
 
-        val behovsVurderingPdf = pdfService.produserBehovsvurderingPdf(behovsVurderingData?.json)
-        val cvPDF = pdfService.produserCVPdf(cvData?.json, produserDokumentDTO.navn, fnr)
-        val arbeidssokerRegistretPdf = pdfService.produserArbeidssokerRegistretPdf(arbeidssokerRegistretData?.json)
+        val behovsVurderingPdf = pdfService.produserBehovsvurderingPdf(behovsVurderingData?.json, mottaker )
+        val cvPDF = pdfService.produserCVPdf(cvData?.json, mottaker)
+        val arbeidssokerRegistretPdf = pdfService.produserArbeidssokerRegistretPdf(arbeidssokerRegistretData?.json, mottaker)
 
 
         return journalforDokument(
@@ -205,7 +207,7 @@ class DokumentService(
 
     companion object {
 
-        fun mapBrevdata(dto: ProduserDokumentDTO, brevdataOppslag: BrevdataOppslag): PdfClient.Brevdata {
+        fun mapBrevdata(dto: ProduserDokumentDTO, brevdataOppslag: BrevdataOppslag): BrevdataDto {
             val dato = LocalDate.now().format(DateFormatters.NORSK_DATE)
             val erIAlderForUngdomsgaranti = erIAlderForUngdomsgaranti(brevdataOppslag.fodselsdatoOgAr)
             val harUngdomsgaranti = erIAlderForUngdomsgaranti &&
@@ -214,7 +216,7 @@ class DokumentService(
                             dto.malType == MalType.SPESIELT_TILPASSET_INNSATS_BEHOLDE_ARBEID ||
                             dto.malType == MalType.SPESIELT_TILPASSET_INNSATS_SKAFFE_ARBEID)
 
-            val mottaker = PdfClient.Mottaker(
+            val mottaker = Mottaker(
                 navn = dto.navn,
                 fodselsnummer = dto.brukerFnr,
             )
@@ -226,7 +228,7 @@ class DokumentService(
             val begrunnelseAvsnitt =
                 dto.begrunnelse?.let { splitNewline(it) }?.filterNot { it.isEmpty() } ?: emptyList()
 
-            return PdfClient.Brevdata(
+            return BrevdataDto(
                 malType = dto.malType,
                 veilederNavn = brevdataOppslag.veilederNavn,
                 navKontor = enhetNavn,

--- a/src/main/java/no/nav/veilarbvedtaksstotte/service/PdfService.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/service/PdfService.kt
@@ -6,7 +6,7 @@ import no.nav.common.types.identer.Fnr
 import no.nav.veilarbvedtaksstotte.client.arbeidssoekeregisteret.OpplysningerOmArbeidssoekerMedProfilering
 import no.nav.veilarbvedtaksstotte.client.dokument.ProduserDokumentDTO
 import no.nav.veilarbvedtaksstotte.client.norg2.EnhetKontaktinformasjon
-import no.nav.veilarbvedtaksstotte.client.pdf.PdfClient
+import no.nav.veilarbvedtaksstotte.client.pdf.*
 import no.nav.veilarbvedtaksstotte.client.person.VeilarbpersonClient
 import no.nav.veilarbvedtaksstotte.client.person.dto.CvInnhold
 import no.nav.veilarbvedtaksstotte.client.veilederogenhet.VeilarbveilederClient
@@ -33,16 +33,18 @@ class PdfService(
         return pdfClient.genererPdf(brevdata)
     }
 
-    fun produserBehovsvurderingPdf(data: String?): Optional<ByteArray> {
+    fun produserBehovsvurderingPdf(data: String?, mottaker: Mottaker): Optional<ByteArray> {
         try {
             if (data == null) return Optional.empty()
 
             val egenvurderingResponseDTO =
                 JsonUtils.objectMapper.readValue(data, EgenvurderingDto::class.java);
 
+            val egenvurderingMedMottaker = EgenvurderingMedMottakerDto.from(egenvurderingResponseDTO, mottaker)
+
             return Optional.ofNullable(
                 pdfClient.genererOyeblikksbildeEgenVurderingPdf(
-                    egenvurderingResponseDTO
+                    egenvurderingMedMottaker
                 )
             )
         } catch (e: Exception) {
@@ -51,16 +53,19 @@ class PdfService(
         }
     }
 
-    fun produserArbeidssokerRegistretPdf(data: String?): Optional<ByteArray> {
+    fun produserArbeidssokerRegistretPdf(data: String?, mottaker: Mottaker): Optional<ByteArray> {
         try {
             if (data == null) return Optional.empty()
 
             val registreringsdataResponseDto =
-                JsonUtils.objectMapper.readValue(data, OpplysningerOmArbeidssoekerMedProfilering::class.java);
+                JsonUtils.objectMapper.readValue(data, OpplysningerOmArbeidssoekerMedProfilering::class.java)
+
+            val registreringsdataMedMottaker =
+                OpplysningerOmArbeidssoekerMedProfileringMedMottakerDto.from(registreringsdataResponseDto, mottaker)
 
             return Optional.ofNullable(
                 pdfClient.genererOyeblikksbildeArbeidssokerRegistretPdf(
-                    registreringsdataResponseDto
+                    registreringsdataMedMottaker
                 )
             )
         } catch (e: Exception) {
@@ -69,14 +74,13 @@ class PdfService(
         }
     }
 
-    fun produserCVPdf(data: String?, navn: String, fnr: Fnr): Optional<ByteArray> {
+    fun produserCVPdf(data: String?, mottaker: Mottaker): Optional<ByteArray> {
         try {
             if (data == null) return Optional.empty()
 
             val cvDto =
                 JsonUtils.objectMapper.readValue(data, CvInnhold::class.java);
-            val mottaker = PdfClient.Mottaker(navn, fnr)
-            val cvInnholdMedMottaker = PdfClient.CvInnholdMedMottaker.from(cvDto, mottaker)
+            val cvInnholdMedMottaker = CvInnholdMedMottakerDto.from(cvDto, mottaker)
             return Optional.ofNullable(
                 pdfClient.genererOyeblikksbildeCvPdf(
                     cvInnholdMedMottaker

--- a/src/test/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfClientImplTest.kt
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/client/pdf/PdfClientImplTest.kt
@@ -26,7 +26,7 @@ class PdfClientImplTest {
     @Test
     fun request_til_brev_client_har_forventet_innhold() {
 
-        val brevdata = PdfClient.Brevdata(
+        val brevdata = BrevdataDto(
             malType = MalType.SITUASJONSBESTEMT_INNSATS_SKAFFE_ARBEID,
             veilederNavn = "Veileder Navn",
             navKontor = "Nav kontor",
@@ -34,7 +34,7 @@ class PdfClientImplTest {
             malform = Malform.NB,
             begrunnelse = listOf("Avsnitt 1", "Avsnitt 2"),
             kilder = listOf("Kilde 1", "Kilde 2"),
-            mottaker = PdfClient.Mottaker(
+            mottaker = Mottaker(
                 navn = "Mottaker Navn",
                 fodselsnummer = Fnr.ofValidFnr("12345678910"),
             ),

--- a/src/test/java/no/nav/veilarbvedtaksstotte/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/config/ClientTestConfig.java
@@ -30,7 +30,7 @@ import no.nav.veilarbvedtaksstotte.client.norg2.EnhetKontaktinformasjon;
 import no.nav.veilarbvedtaksstotte.client.norg2.EnhetOrganisering;
 import no.nav.veilarbvedtaksstotte.client.norg2.EnhetStedsadresse;
 import no.nav.veilarbvedtaksstotte.client.norg2.Norg2Client;
-import no.nav.veilarbvedtaksstotte.client.pdf.PdfClient;
+import no.nav.veilarbvedtaksstotte.client.pdf.*;
 import no.nav.veilarbvedtaksstotte.client.person.VeilarbpersonClient;
 import no.nav.veilarbvedtaksstotte.client.person.dto.*;
 import no.nav.veilarbvedtaksstotte.client.regoppslag.RegoppslagClient;
@@ -44,12 +44,10 @@ import no.nav.veilarbvedtaksstotte.client.veilederogenhet.dto.PortefoljeEnhet;
 import no.nav.veilarbvedtaksstotte.client.veilederogenhet.dto.Veileder;
 import no.nav.veilarbvedtaksstotte.client.veilederogenhet.dto.VeilederEnheterDTO;
 import no.nav.veilarbvedtaksstotte.domain.Malform;
-import no.nav.veilarbvedtaksstotte.domain.oyeblikksbilde.EgenvurderingDto;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.Instant;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Collections;
@@ -168,25 +166,25 @@ public class ClientTestConfig {
 
             @NotNull
             @Override
-            public byte[] genererOyeblikksbildeArbeidssokerRegistretPdf(@NotNull OpplysningerOmArbeidssoekerMedProfilering registreringOyeblikksbildeData) {
+            public byte[] genererOyeblikksbildeArbeidssokerRegistretPdf(@NotNull OpplysningerOmArbeidssoekerMedProfileringMedMottakerDto registreringOyeblikksbildeData) {
                 return new byte[0];
             }
 
             @NotNull
             @Override
-            public byte[] genererOyeblikksbildeEgenVurderingPdf(@NotNull EgenvurderingDto egenvurderingOyeblikksbildeData) {
+            public byte[] genererOyeblikksbildeEgenVurderingPdf(@NotNull EgenvurderingMedMottakerDto egenvurderingOyeblikksbildeData) {
                 return new byte[0];
             }
 
             @NotNull
             @Override
-            public byte[] genererOyeblikksbildeCvPdf(@NotNull CvInnholdMedMottaker cvOyeblikksbildeData) {
+            public byte[] genererOyeblikksbildeCvPdf(@NotNull CvInnholdMedMottakerDto cvOyeblikksbildeData) {
                 return new byte[0];
             }
 
             @NotNull
             @Override
-            public byte[] genererPdf(@NotNull Brevdata brevdata) {
+            public byte[] genererPdf(@NotNull BrevdataDto brevdata) {
                 return new byte[0];
             }
 

--- a/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
+++ b/src/test/java/no/nav/veilarbvedtaksstotte/service/VedtakServiceTest.java
@@ -227,8 +227,8 @@ public class VedtakServiceTest extends DatabaseTest {
         when(enhetInfoService.utledEnhetKontaktinformasjon(EnhetId.of(TEST_OPPFOLGINGSENHET_ID)))
                 .thenReturn(new EnhetKontaktinformasjon(EnhetId.of(TEST_OPPFOLGINGSENHET_ID), new EnhetStedsadresse("", "", "", "", "", ""), ""));
         when(pdfService.produserDokument(any())).thenReturn(new byte[]{});
-        when(pdfService.produserCVPdf(any(), any(), any())).thenReturn(Optional.of(new byte[]{}));
-        when(pdfService.produserBehovsvurderingPdf(any())).thenReturn(Optional.of(new byte[]{}));
+        when(pdfService.produserCVPdf(any(), any())).thenReturn(Optional.of(new byte[]{}));
+        when(pdfService.produserBehovsvurderingPdf(any(), any())).thenReturn(Optional.of(new byte[]{}));
         when(poaoTilgangClient.evaluatePolicy(any())).thenReturn(new ApiResult<>(null, Decision.Permit.INSTANCE));
         when(safClient.hentJournalpost(any())).thenReturn(getMockedJournalpostGraphqlResponse());
     }


### PR DESCRIPTION
Sender med mottaker (navn og fnr) til brevløsningen slik at disse kan vises øverst i øyeblikksbrevene. 

Flyttet pdf-dto klassene til en egen domenefil