### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -67,7 +67,9 @@ spec:
       value: api://dev-fss.teamdokumenthandtering.dokarkiv/.default
     - name: DOKARKIV_URL
       value: https://dokarkiv-q2.dev-fss-pub.nais.io
-    - name: DOKDISTFORDELING_URL # bruker saf-scope
+    - name: DOKDISTFORDELING_TOKEN_SCOPE
+      value: api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default
+    - name: DOKDISTFORDELING_URL
       value: https://dokdistfordeling.dev-fss-pub.nais.io
     - name: DOKDISTKANAL_TOKEN_SCOPE
       value: api://dev-fss.teamdokumenthandtering.dokdistkanal/.default

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -62,7 +62,9 @@ spec:
       value: api://prod-fss.teamdokumenthandtering.dokarkiv/.default
     - name: DOKARKIV_URL
       value: https://dokarkiv.prod-fss-pub.nais.io
-    - name: DOKDISTFORDELING_URL # bruker saf-scope
+    - name: DOKDISTFORDELING_TOKEN_SCOPE
+      value: api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default
+    - name: DOKDISTFORDELING_URL
       value: https://dokdistfordeling.prod-fss-pub.nais.io
     - name: DOKDISTKANAL_TOKEN_SCOPE
       value: api://prod-fss.teamdokumenthandtering.dokdistkanal/.default

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/ClientConfig.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/ClientConfig.kt
@@ -176,10 +176,9 @@ class ClientConfig {
     fun dokDistribusjonClient(
         properties: EnvironmentProperties, machineTokenClient: AzureAdMachineToMachineTokenClient
     ): DokdistribusjonClient {
-        // dokdistfordeling bruker saf token scope
         return DokdistribusjonClientImpl(properties.dokdistfordelingUrl) {
             machineTokenClient.createMachineToMachineToken(
-                properties.safScope
+                properties.dokdistfordelingScope
             )
         }
     }

--- a/src/main/java/no/nav/veilarbvedtaksstotte/config/EnvironmentProperties.kt
+++ b/src/main/java/no/nav/veilarbvedtaksstotte/config/EnvironmentProperties.kt
@@ -9,6 +9,7 @@ data class EnvironmentProperties (
     val dbUrl: String,
     val dokarkivScope: String,
     val dokarkivUrl: String,
+    val dokdistfordelingScope: String,
     val dokdistfordelingUrl: String,
     val dokdistkanalScope: String,
     val dokdistkanalUrl: String,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,7 @@ app.env.aiaBackendUrl=${AIA_BACKEND_URL}
 app.env.dbUrl=${DB_JDBC_URL}
 app.env.dokarkivScope=${DOKARKIV_TOKEN_SCOPE}
 app.env.dokarkivUrl=${DOKARKIV_URL}
+app.env.dokdistfordelingScope=${DOKDISTFORDELING_TOKEN_SCOPE}
 app.env.dokdistfordelingUrl=${DOKDISTFORDELING_URL}
 app.env.dokdistkanalScope=${DOKDISTKANAL_TOKEN_SCOPE}
 app.env.dokdistkanalUrl=${DOKDISTKANAL_URL}


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen
* Introdusert ny `app.env.dokdistfordelingScope`
* Introdusert ny ENV `DOKDISTFORDELING_TOKEN_SCOPE`
* Endret `dokDistribusjonClient` til å bruke `dokdistfordelingScope` i stedet for `safScope`