### PR TITLE
fix. rett cluster fra dev-fss til prod-fss for tiltaksgjennomforing-api i accessPolicy

### DIFF
--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -165,7 +165,7 @@ spec:
         # Lenke til behandling i Behandlingskatalogen: https://behandlingskatalog.ansatt.nav.no/process/team/0150fd7c-df30-43ee-944e-b152d74c64d6/780e3168-cf58-46ec-9764-a6cdd3da3b8f
         - application: tiltaksgjennomforing-api
           namespace: arbeidsgiver
-          cluster: dev-fss
+          cluster: prod-fss
           permissions:
             roles:
               - "gjeldende-14a-vedtak"


### PR DESCRIPTION
Tilgang fra tiltaksgjennomforing-api (namespace arbeidsgiver) var feilaktig konfigurert med cluster dev-fss i produksjonskonfigurasjonen. Rettet til prod-fss slik at tjenesten faktisk får tilgang i produksjonsmiljøet.